### PR TITLE
Add CPP vulnerable samples batch 1/2

### DIFF
--- a/cpp/client.cpp
+++ b/cpp/client.cpp
@@ -1,0 +1,1106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <arrow-glib/arrow-glib.hpp>
+
+#include <arrow-flight-glib/client.hpp>
+#include <arrow-flight-glib/common.hpp>
+
+G_BEGIN_DECLS
+
+/**
+ * SECTION: client
+ * @section_id: client
+ * @title: Client related classes
+ * @include: arrow-flight-glib/arrow-flight-glib.h
+ *
+ * #GAFlightStreamReader is a class for reading record batches from a
+ * server.
+ *
+ * #GAFlightStreamWriter is a class for writing record batches to a
+ * server.
+ *
+ * #GAFlightMetadataReader is a class for reading metadata from a
+ * server.
+ *
+ * #GAFlightCallOptions is a class for options of each call.
+ *
+ * #GAFlightClientOptions is a class for options of each client.
+ *
+ * #GAFlightDoPutResult is a class that has gaflight_client_do_put()
+ * result.
+ *
+ * #GAFlightClient is a class for Apache Arrow Flight client.
+ *
+ * Since: 5.0.0
+ */
+
+G_DEFINE_TYPE(GAFlightStreamReader,
+              gaflight_stream_reader,
+              GAFLIGHT_TYPE_RECORD_BATCH_READER)
+
+static void
+gaflight_stream_reader_init(GAFlightStreamReader *object)
+{
+}
+
+static void
+gaflight_stream_reader_class_init(GAFlightStreamReaderClass *klass)
+{
+}
+
+G_DEFINE_TYPE(GAFlightStreamWriter,
+              gaflight_stream_writer,
+              GAFLIGHT_TYPE_RECORD_BATCH_WRITER)
+
+static void
+gaflight_stream_writer_init(GAFlightStreamWriter *object)
+{
+}
+
+static void
+gaflight_stream_writer_class_init(GAFlightStreamWriterClass *klass)
+{
+}
+
+/**
+ * gaflight_stream_writer_done_writing:
+ * @writer: A #GAFlightStreamWriter.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 18.0.0
+ */
+gboolean
+gaflight_stream_writer_done_writing(GAFlightStreamWriter *writer, GError **error)
+{
+  auto flight_writer = std::static_pointer_cast<arrow::flight::FlightStreamWriter>(
+    garrow_record_batch_writer_get_raw(GARROW_RECORD_BATCH_WRITER(writer)));
+  return garrow::check(error,
+                       flight_writer->DoneWriting(),
+                       "[flight-stream-writer][done-writing]");
+}
+
+struct GAFlightMetadataReaderPrivate
+{
+  arrow::flight::FlightMetadataReader *reader;
+};
+
+enum {
+  PROP_METADATA_READER_READER = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightMetadataReader,
+                           gaflight_metadata_reader,
+                           G_TYPE_OBJECT)
+
+#define GAFLIGHT_METADATA_READER_GET_PRIVATE(object)                                     \
+  static_cast<GAFlightMetadataReaderPrivate *>(                                          \
+    gaflight_metadata_reader_get_instance_private(GAFLIGHT_METADATA_READER(object)))
+
+static void
+gaflight_metadata_reader_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_METADATA_READER_GET_PRIVATE(object);
+  delete priv->reader;
+  G_OBJECT_CLASS(gaflight_metadata_reader_parent_class)->finalize(object);
+}
+
+static void
+gaflight_metadata_reader_set_property(GObject *object,
+                                      guint prop_id,
+                                      const GValue *value,
+                                      GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_METADATA_READER_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_METADATA_READER_READER:
+    priv->reader =
+      static_cast<arrow::flight::FlightMetadataReader *>(g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_metadata_reader_init(GAFlightMetadataReader *object)
+{
+}
+
+static void
+gaflight_metadata_reader_class_init(GAFlightMetadataReaderClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_metadata_reader_finalize;
+  gobject_class->set_property = gaflight_metadata_reader_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "reader",
+    nullptr,
+    nullptr,
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_METADATA_READER_READER, spec);
+}
+
+/**
+ * gaflight_metadata_reader_read:
+ * @reader: A #GAFlightMetadataReader.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): The metadata on success, %NULL on error.
+ *
+ * Since: 18.0.0
+ */
+GArrowBuffer *
+gaflight_metadata_reader_read(GAFlightMetadataReader *reader, GError **error)
+{
+  auto flight_reader = gaflight_metadata_reader_get_raw(reader);
+  std::shared_ptr<arrow::Buffer> metadata;
+  if (garrow::check(error,
+                    flight_reader->ReadMetadata(&metadata),
+                    "[flight-metadata-reader][read]")) {
+    return garrow_buffer_new_raw(&metadata);
+  } else {
+    return nullptr;
+  }
+}
+
+struct GAFlightCallOptionsPrivate
+{
+  arrow::flight::FlightCallOptions options;
+};
+
+enum {
+  PROP_TIMEOUT = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightCallOptions, gaflight_call_options, G_TYPE_OBJECT)
+
+#define GAFLIGHT_CALL_OPTIONS_GET_PRIVATE(object)                                        \
+  static_cast<GAFlightCallOptionsPrivate *>(                                             \
+    gaflight_call_options_get_instance_private(GAFLIGHT_CALL_OPTIONS(object)))
+
+static void
+gaflight_call_options_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_CALL_OPTIONS_GET_PRIVATE(object);
+
+  priv->options.~FlightCallOptions();
+
+  G_OBJECT_CLASS(gaflight_call_options_parent_class)->finalize(object);
+}
+
+static void
+gaflight_call_options_set_property(GObject *object,
+                                   guint prop_id,
+                                   const GValue *value,
+                                   GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_CALL_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_TIMEOUT:
+    priv->options.timeout = arrow::flight::TimeoutDuration(g_value_get_double(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_call_options_get_property(GObject *object,
+                                   guint prop_id,
+                                   GValue *value,
+                                   GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_CALL_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_TIMEOUT:
+    g_value_set_double(value, priv->options.timeout.count());
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_call_options_init(GAFlightCallOptions *object)
+{
+  auto priv = GAFLIGHT_CALL_OPTIONS_GET_PRIVATE(object);
+  new (&priv->options) arrow::flight::FlightCallOptions;
+}
+
+static void
+gaflight_call_options_class_init(GAFlightCallOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_call_options_finalize;
+  gobject_class->set_property = gaflight_call_options_set_property;
+  gobject_class->get_property = gaflight_call_options_get_property;
+
+  arrow::flight::FlightCallOptions options;
+  GParamSpec *spec;
+  /**
+   * GAFlightCallOptions:timeout:
+   *
+   * An optional timeout for this call. Negative durations mean an
+   * implementation-defined default behavior will be used
+   * instead. This is the default value.
+   *
+   * Since: 18.0.0
+   */
+  spec = g_param_spec_double("timeout",
+                             nullptr,
+                             nullptr,
+                             -G_MAXDOUBLE,
+                             G_MAXDOUBLE,
+                             options.timeout.count(),
+                             static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_TIMEOUT, spec);
+}
+
+/**
+ * gaflight_call_options_new:
+ *
+ * Returns: The newly created options for a call.
+ *
+ * Since: 5.0.0
+ */
+GAFlightCallOptions *
+gaflight_call_options_new(void)
+{
+  return static_cast<GAFlightCallOptions *>(
+    g_object_new(GAFLIGHT_TYPE_CALL_OPTIONS, NULL));
+}
+
+/**
+ * gaflight_call_options_add_header:
+ * @options: A #GAFlightCallOptions.
+ * @name: A header name.
+ * @value: A header value.
+ *
+ * Add a header.
+ *
+ * Since: 9.0.0
+ */
+void
+gaflight_call_options_add_header(GAFlightCallOptions *options,
+                                 const gchar *name,
+                                 const gchar *value)
+{
+  auto flight_options = gaflight_call_options_get_raw(options);
+  flight_options->headers.emplace_back(name, value);
+}
+
+/**
+ * gaflight_call_options_clear_headers:
+ * @options: A #GAFlightCallOptions.
+ *
+ * Clear all headers.
+ *
+ * Since: 9.0.0
+ */
+void
+gaflight_call_options_clear_headers(GAFlightCallOptions *options)
+{
+  auto flight_options = gaflight_call_options_get_raw(options);
+  flight_options->headers.clear();
+}
+
+/**
+ * gaflight_call_options_foreach_header:
+ * @options: A #GAFlightCallOptions.
+ * @func: (scope call) (closure user_data): The user's callback function.
+ * @user_data: Data for @func.
+ *
+ * Iterates over all headers in the options.
+ *
+ * Since: 9.0.0
+ */
+void
+gaflight_call_options_foreach_header(GAFlightCallOptions *options,
+                                     GAFlightHeaderFunc func,
+                                     gpointer user_data)
+{
+  auto flight_options = gaflight_call_options_get_raw(options);
+  for (const auto &header : flight_options->headers) {
+    auto &key = header.first;
+    auto &value = header.second;
+    func(key.c_str(), value.c_str(), user_data);
+  }
+}
+
+struct GAFlightClientOptionsPrivate
+{
+  arrow::flight::FlightClientOptions options;
+};
+
+enum {
+  PROP_TLS_ROOT_CERTIFICATES = 1,
+  PROP_OVERRIDE_HOST_NAME,
+  PROP_CERTIFICATE_CHAIN,
+  PROP_PRIVATE_KEY,
+  PROP_WRITE_SIZE_LIMIT_BYTES,
+  PROP_DISABLE_SERVER_VERIFICATION,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightClientOptions, gaflight_client_options, G_TYPE_OBJECT)
+
+#define GAFLIGHT_CLIENT_OPTIONS_GET_PRIVATE(obj)                                         \
+  static_cast<GAFlightClientOptionsPrivate *>(                                           \
+    gaflight_client_options_get_instance_private(GAFLIGHT_CLIENT_OPTIONS(obj)))
+
+static void
+gaflight_client_options_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_CLIENT_OPTIONS_GET_PRIVATE(object);
+
+  priv->options.~FlightClientOptions();
+
+  G_OBJECT_CLASS(gaflight_client_options_parent_class)->finalize(object);
+}
+
+static void
+gaflight_client_options_set_property(GObject *object,
+                                     guint prop_id,
+                                     const GValue *value,
+                                     GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_CLIENT_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_TLS_ROOT_CERTIFICATES:
+    priv->options.tls_root_certs = g_value_get_string(value);
+    break;
+  case PROP_OVERRIDE_HOST_NAME:
+    priv->options.override_hostname = g_value_get_string(value);
+    break;
+  case PROP_CERTIFICATE_CHAIN:
+    priv->options.cert_chain = g_value_get_string(value);
+    break;
+  case PROP_PRIVATE_KEY:
+    priv->options.private_key = g_value_get_string(value);
+    break;
+  case PROP_WRITE_SIZE_LIMIT_BYTES:
+    priv->options.write_size_limit_bytes = g_value_get_int64(value);
+    break;
+  case PROP_DISABLE_SERVER_VERIFICATION:
+    priv->options.disable_server_verification = g_value_get_boolean(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_client_options_get_property(GObject *object,
+                                     guint prop_id,
+                                     GValue *value,
+                                     GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_CLIENT_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_TLS_ROOT_CERTIFICATES:
+    g_value_set_string(value, priv->options.tls_root_certs.c_str());
+    break;
+  case PROP_OVERRIDE_HOST_NAME:
+    g_value_set_string(value, priv->options.override_hostname.c_str());
+    break;
+  case PROP_CERTIFICATE_CHAIN:
+    g_value_set_string(value, priv->options.cert_chain.c_str());
+    break;
+  case PROP_PRIVATE_KEY:
+    g_value_set_string(value, priv->options.private_key.c_str());
+    break;
+  case PROP_WRITE_SIZE_LIMIT_BYTES:
+    g_value_set_int64(value, priv->options.write_size_limit_bytes);
+    break;
+  case PROP_DISABLE_SERVER_VERIFICATION:
+    g_value_set_boolean(value, priv->options.disable_server_verification);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_client_options_init(GAFlightClientOptions *object)
+{
+  auto priv = GAFLIGHT_CLIENT_OPTIONS_GET_PRIVATE(object);
+  new (&(priv->options)) arrow::flight::FlightClientOptions;
+  priv->options = arrow::flight::FlightClientOptions::Defaults();
+}
+
+static void
+gaflight_client_options_class_init(GAFlightClientOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_client_options_finalize;
+  gobject_class->set_property = gaflight_client_options_set_property;
+  gobject_class->get_property = gaflight_client_options_get_property;
+
+  auto options = arrow::flight::FlightClientOptions::Defaults();
+  GParamSpec *spec;
+  /**
+   * GAFlightClientOptions:tls-root-certificates:
+   *
+   * Root certificates to use for validating server certificates.
+   *
+   * Since: 14.0.0
+   */
+  spec = g_param_spec_string("tls-root-certificates",
+                             nullptr,
+                             nullptr,
+                             options.tls_root_certs.c_str(),
+                             static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_TLS_ROOT_CERTIFICATES, spec);
+
+  /**
+   * GAFlightClientOptions:override-host-name:
+   *
+   * Override the host name checked by TLS. Use with caution.
+   *
+   * Since: 14.0.0
+   */
+  spec = g_param_spec_string("override-host-name",
+                             nullptr,
+                             nullptr,
+                             options.override_hostname.c_str(),
+                             static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_OVERRIDE_HOST_NAME, spec);
+
+  /**
+   * GAFlightClientOptions:certificate-chain:
+   *
+   * The client certificate to use if using Mutual TLS.
+   *
+   * Since: 14.0.0
+   */
+  spec = g_param_spec_string("certificate-chain",
+                             nullptr,
+                             nullptr,
+                             options.cert_chain.c_str(),
+                             static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_CERTIFICATE_CHAIN, spec);
+
+  /**
+   * GAFlightClientOptions:private-key:
+   *
+   * The private key associated with the client certificate for Mutual
+   * TLS.
+   *
+   * Since: 14.0.0
+   */
+  spec = g_param_spec_string("private-key",
+                             nullptr,
+                             nullptr,
+                             options.private_key.c_str(),
+                             static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_PRIVATE_KEY, spec);
+
+  /**
+   * GAFlightClientOptions:write-size-limit-bytes:
+   *
+   * A soft limit on the number of bytes to write in a single batch
+   * when sending Arrow data to a server.
+   *
+   * Used to help limit server memory consumption. Only enabled if
+   * positive. When enabled, @GARROW_ERROR_IO may be yielded.
+   *
+   * Since: 14.0.0
+   */
+  spec = g_param_spec_int64("write-size-limit-bytes",
+                            nullptr,
+                            nullptr,
+                            INT64_MIN,
+                            INT64_MAX,
+                            options.write_size_limit_bytes,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_WRITE_SIZE_LIMIT_BYTES, spec);
+
+  /**
+   * GAFlightClientOptions:disable-server-verification:
+   *
+   * Whether use TLS without validating the server certificate. Use
+   * with caution.
+   *
+   * Since: 9.0.0
+   */
+  spec = g_param_spec_boolean("disable-server-verification",
+                              NULL,
+                              NULL,
+                              options.disable_server_verification,
+                              static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_DISABLE_SERVER_VERIFICATION, spec);
+}
+
+/**
+ * gaflight_client_options_new:
+ *
+ * Returns: The newly created options for a client.
+ *
+ * Since: 5.0.0
+ */
+GAFlightClientOptions *
+gaflight_client_options_new(void)
+{
+  return static_cast<GAFlightClientOptions *>(
+    g_object_new(GAFLIGHT_TYPE_CLIENT_OPTIONS, NULL));
+}
+
+struct GAFlightDoPutResultPrivate
+{
+  GAFlightStreamWriter *writer;
+  GAFlightMetadataReader *reader;
+};
+
+enum {
+  PROP_DO_PUT_RESULT_RESULT = 1,
+  PROP_DO_PUT_RESULT_WRITER,
+  PROP_DO_PUT_RESULT_READER,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightDoPutResult, gaflight_do_put_result, G_TYPE_OBJECT)
+
+#define GAFLIGHT_DO_PUT_RESULT_GET_PRIVATE(object)                                       \
+  static_cast<GAFlightDoPutResultPrivate *>(                                             \
+    gaflight_do_put_result_get_instance_private(GAFLIGHT_DO_PUT_RESULT(object)))
+
+static void
+gaflight_do_put_result_dispose(GObject *object)
+{
+  auto priv = GAFLIGHT_DO_PUT_RESULT_GET_PRIVATE(object);
+
+  if (priv->writer) {
+    g_object_unref(priv->writer);
+    priv->writer = nullptr;
+  }
+
+  if (priv->reader) {
+    g_object_unref(priv->reader);
+    priv->reader = nullptr;
+  }
+
+  G_OBJECT_CLASS(gaflight_do_put_result_parent_class)->dispose(object);
+}
+
+static void
+gaflight_do_put_result_init(GAFlightDoPutResult *object)
+{
+}
+
+static void
+gaflight_do_put_result_set_property(GObject *object,
+                                    guint prop_id,
+                                    const GValue *value,
+                                    GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_DO_PUT_RESULT_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_DO_PUT_RESULT_RESULT:
+    {
+      auto result = static_cast<arrow::flight::FlightClient::DoPutResult *>(
+        g_value_get_pointer(value));
+      std::shared_ptr<arrow::flight::FlightStreamWriter> writer =
+        std::move(result->writer);
+      priv->writer = gaflight_stream_writer_new_raw(&writer);
+      priv->reader = gaflight_metadata_reader_new_raw(result->reader.release());
+      break;
+    }
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_do_put_result_get_property(GObject *object,
+                                    guint prop_id,
+                                    GValue *value,
+                                    GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_DO_PUT_RESULT_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_DO_PUT_RESULT_WRITER:
+    g_value_set_object(value, priv->writer);
+    break;
+  case PROP_DO_PUT_RESULT_READER:
+    g_value_set_object(value, priv->reader);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_do_put_result_class_init(GAFlightDoPutResultClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = gaflight_do_put_result_dispose;
+  gobject_class->set_property = gaflight_do_put_result_set_property;
+  gobject_class->get_property = gaflight_do_put_result_get_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "result",
+    nullptr,
+    nullptr,
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_DO_PUT_RESULT_RESULT, spec);
+
+  /**
+   * GAFlightDoPutResult:writer:
+   *
+   * A writer to write record batches to.
+   *
+   * Since: 18.0.0
+   */
+  spec = g_param_spec_object("writer",
+                             nullptr,
+                             nullptr,
+                             GAFLIGHT_TYPE_STREAM_WRITER,
+                             static_cast<GParamFlags>(G_PARAM_READABLE));
+  g_object_class_install_property(gobject_class, PROP_DO_PUT_RESULT_WRITER, spec);
+
+  /**
+   * GAFlightDoPutResult:reader:
+   *
+   * A reader for application metadata from the server.
+   *
+   * Since: 18.0.0
+   */
+  spec = g_param_spec_object("reader",
+                             nullptr,
+                             nullptr,
+                             GAFLIGHT_TYPE_METADATA_READER,
+                             static_cast<GParamFlags>(G_PARAM_READABLE));
+  g_object_class_install_property(gobject_class, PROP_DO_PUT_RESULT_READER, spec);
+}
+
+struct GAFlightClientPrivate
+{
+  std::shared_ptr<arrow::flight::FlightClient> client;
+};
+
+enum {
+  PROP_CLIENT = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightClient, gaflight_client, G_TYPE_OBJECT)
+
+#define GAFLIGHT_CLIENT_GET_PRIVATE(obj)                                                 \
+  static_cast<GAFlightClientPrivate *>(                                                  \
+    gaflight_client_get_instance_private(GAFLIGHT_CLIENT(obj)))
+
+static void
+gaflight_client_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_CLIENT_GET_PRIVATE(object);
+
+  priv->client.~shared_ptr();
+
+  G_OBJECT_CLASS(gaflight_client_parent_class)->finalize(object);
+}
+
+static void
+gaflight_client_set_property(GObject *object,
+                             guint prop_id,
+                             const GValue *value,
+                             GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_CLIENT_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_CLIENT:
+    priv->client = *(static_cast<std::shared_ptr<arrow::flight::FlightClient> *>(
+      g_value_get_pointer(value)));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_client_init(GAFlightClient *object)
+{
+  auto priv = GAFLIGHT_CLIENT_GET_PRIVATE(object);
+  new (&priv->client) std::shared_ptr<arrow::flight::FlightClient>;
+}
+
+static void
+gaflight_client_class_init(GAFlightClientClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_client_finalize;
+  gobject_class->set_property = gaflight_client_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "client",
+    "Client",
+    "The raw std::shared_ptr<arrow::flight::FlightClient>",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_CLIENT, spec);
+}
+
+/**
+ * gaflight_client_new:
+ * @location: A #GAFlightLocation to be connected.
+ * @options: (nullable): A #GAFlightClientOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable): The newly created client, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GAFlightClient *
+gaflight_client_new(GAFlightLocation *location,
+                    GAFlightClientOptions *options,
+                    GError **error)
+{
+  const auto flight_location = gaflight_location_get_raw(location);
+  arrow::Result<std::unique_ptr<arrow::flight::FlightClient>> result;
+  if (options) {
+    const auto flight_options = gaflight_client_options_get_raw(options);
+    result = arrow::flight::FlightClient::Connect(*flight_location, *flight_options);
+  } else {
+    result = arrow::flight::FlightClient::Connect(*flight_location);
+  }
+  if (garrow::check(error, result, "[flight-client][new]")) {
+    std::shared_ptr<arrow::flight::FlightClient> flight_client = std::move(*result);
+    return gaflight_client_new_raw(&flight_client);
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * gaflight_client_close:
+ * @client: A #GAFlightClient.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 8.0.0
+ */
+gboolean
+gaflight_client_close(GAFlightClient *client, GError **error)
+{
+  auto flight_client = gaflight_client_get_raw(client);
+  auto status = flight_client->Close();
+  return garrow::check(error, status, "[flight-client][close]");
+}
+
+/**
+ * gaflight_client_authenticate_basic_token:
+ * @client: A #GAFlightClient.
+ * @user: User name to be used.
+ * @password: Password to be used.
+ * @options: (nullable): A #GAFlightCallOptions.
+ * @bearer_name: (out) (transfer full): Bearer token name on success.
+ * @bearer_value: (out) (transfer full): Bearer token value on success.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Authenticates to the server using basic HTTP style authentication.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 12.0.0
+ */
+gboolean
+gaflight_client_authenticate_basic_token(GAFlightClient *client,
+                                         const gchar *user,
+                                         const gchar *password,
+                                         GAFlightCallOptions *options,
+                                         gchar **bearer_name,
+                                         gchar **bearer_value,
+                                         GError **error)
+{
+  auto flight_client = gaflight_client_get_raw(client);
+  arrow::flight::FlightCallOptions flight_default_options;
+  auto flight_options = &flight_default_options;
+  if (options) {
+    flight_options = gaflight_call_options_get_raw(options);
+  }
+  auto result = flight_client->AuthenticateBasicToken(*flight_options, user, password);
+  if (!garrow::check(error, result, "[flight-client][authenticate-basic-token]")) {
+    return FALSE;
+  }
+  auto bearer_token = *result;
+  *bearer_name = g_strndup(bearer_token.first.data(), bearer_token.first.size());
+  *bearer_value = g_strndup(bearer_token.second.data(), bearer_token.second.size());
+  return TRUE;
+}
+
+/**
+ * gaflight_client_list_flights:
+ * @client: A #GAFlightClient.
+ * @criteria: (nullable): A #GAFlightCriteria.
+ * @options: (nullable): A #GAFlightCallOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable) (element-type GAFlightInfo) (transfer full):
+ *   The returned list of #GAFlightInfo on success, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GList *
+gaflight_client_list_flights(GAFlightClient *client,
+                             GAFlightCriteria *criteria,
+                             GAFlightCallOptions *options,
+                             GError **error)
+{
+  auto flight_client = gaflight_client_get_raw(client);
+  arrow::flight::Criteria flight_default_criteria;
+  auto flight_criteria = &flight_default_criteria;
+  if (criteria) {
+    flight_criteria = gaflight_criteria_get_raw(criteria);
+  }
+  arrow::flight::FlightCallOptions flight_default_options;
+  auto flight_options = &flight_default_options;
+  if (options) {
+    flight_options = gaflight_call_options_get_raw(options);
+  }
+  std::unique_ptr<arrow::flight::FlightListing> flight_listing;
+  auto result = flight_client->ListFlights(*flight_options, *flight_criteria);
+  auto status = std::move(result).Value(&flight_listing);
+  if (!garrow::check(error, status, "[flight-client][list-flights]")) {
+    return NULL;
+  }
+  GList *listing = NULL;
+  std::unique_ptr<arrow::flight::FlightInfo> flight_info;
+  while (true) {
+    status = flight_listing->Next().Value(&flight_info);
+    if (!garrow::check(error, status, "[flight-client][list-flights]")) {
+      g_list_free_full(listing, g_object_unref);
+      return NULL;
+    }
+    if (!flight_info) {
+      break;
+    }
+    auto info = gaflight_info_new_raw(flight_info.release());
+    listing = g_list_prepend(listing, info);
+  }
+  return g_list_reverse(listing);
+}
+
+/**
+ * gaflight_client_get_flight_info:
+ * @client: A #GAFlightClient.
+ * @descriptor: A #GAFlightDescriptor to be processed.
+ * @options: (nullable): A #GAFlightCallOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable) (transfer full): The returned #GAFlightInfo on
+ *   success, %NULL on error.
+ *
+ * Since: 9.0.0
+ */
+GAFlightInfo *
+gaflight_client_get_flight_info(GAFlightClient *client,
+                                GAFlightDescriptor *descriptor,
+                                GAFlightCallOptions *options,
+                                GError **error)
+{
+  auto flight_client = gaflight_client_get_raw(client);
+  auto flight_descriptor = gaflight_descriptor_get_raw(descriptor);
+  arrow::flight::FlightCallOptions flight_default_options;
+  auto flight_options = &flight_default_options;
+  if (options) {
+    flight_options = gaflight_call_options_get_raw(options);
+  }
+  auto result = flight_client->GetFlightInfo(*flight_options, *flight_descriptor);
+  if (!garrow::check(error, result, "[flight-client][get-flight-info]")) {
+    return NULL;
+  }
+  auto flight_info = std::move(*result);
+  return gaflight_info_new_raw(flight_info.release());
+}
+
+/**
+ * gaflight_client_do_get:
+ * @client: A #GAFlightClient.
+ * @ticket: A #GAFlightTicket.
+ * @options: (nullable): A #GAFlightCallOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable) (transfer full):
+ *   The #GAFlightStreamReader to read record batched from the server
+ *   on success, %NULL on error.
+ *
+ * Since: 6.0.0
+ */
+GAFlightStreamReader *
+gaflight_client_do_get(GAFlightClient *client,
+                       GAFlightTicket *ticket,
+                       GAFlightCallOptions *options,
+                       GError **error)
+{
+  auto flight_client = gaflight_client_get_raw(client);
+  const auto flight_ticket = gaflight_ticket_get_raw(ticket);
+  arrow::flight::FlightCallOptions flight_default_options;
+  auto flight_options = &flight_default_options;
+  if (options) {
+    flight_options = gaflight_call_options_get_raw(options);
+  }
+  auto result = flight_client->DoGet(*flight_options, *flight_ticket);
+  if (!garrow::check(error, result, "[flight-client][do-get]")) {
+    return nullptr;
+  }
+  auto flight_reader = std::move(*result);
+  return gaflight_stream_reader_new_raw(flight_reader.release(), TRUE);
+}
+
+/**
+ * gaflight_client_do_put:
+ * @client: A #GAFlightClient.
+ * @descriptor: A #GAFlightDescriptor.
+ * @schema: A #GArrowSchema.
+ * @options: (nullable): A #GAFlightCallOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Upload data to a Flight described by the given descriptor. The
+ * caller must call garrow_record_batch_writer_close() on the
+ * returned stream once they are done writing.
+ *
+ * The reader and writer are linked; closing the writer will also
+ * close the reader. Use garrow_flight_stream_writer_done_writing() to
+ * only close the write side of the channel.
+ *
+ * Returns: (nullable) (transfer full):
+ *   The #GAFlighDoPutResult holding a reader and a writer on success,
+ *   %NULL on error.
+ *
+ * Since: 18.0.0
+ */
+GAFlightDoPutResult *
+gaflight_client_do_put(GAFlightClient *client,
+                       GAFlightDescriptor *descriptor,
+                       GArrowSchema *schema,
+                       GAFlightCallOptions *options,
+                       GError **error)
+{
+  auto flight_client = gaflight_client_get_raw(client);
+  auto flight_descriptor = gaflight_descriptor_get_raw(descriptor);
+  auto arrow_schema = garrow_schema_get_raw(schema);
+  arrow::flight::FlightCallOptions flight_default_options;
+  auto flight_options = &flight_default_options;
+  if (options) {
+    flight_options = gaflight_call_options_get_raw(options);
+  }
+  auto result = flight_client->DoPut(*flight_options, *flight_descriptor, arrow_schema);
+  if (!garrow::check(error, result, "[flight-client][do-put]")) {
+    return nullptr;
+  }
+  auto flight_result = std::move(*result);
+  return gaflight_do_put_result_new_raw(&flight_result);
+}
+
+G_END_DECLS
+
+GAFlightStreamReader *
+gaflight_stream_reader_new_raw(arrow::flight::FlightStreamReader *flight_reader,
+                               gboolean is_owner)
+{
+  return GAFLIGHT_STREAM_READER(g_object_new(GAFLIGHT_TYPE_STREAM_READER,
+                                             "reader",
+                                             flight_reader,
+                                             "is-owner",
+                                             is_owner,
+                                             nullptr));
+}
+
+GAFlightStreamWriter *
+gaflight_stream_writer_new_raw(
+  std::shared_ptr<arrow::flight::FlightStreamWriter> *flight_writer)
+{
+  return GAFLIGHT_STREAM_WRITER(g_object_new(GAFLIGHT_TYPE_STREAM_WRITER,
+                                             "record-batch-writer",
+                                             flight_writer,
+                                             nullptr));
+}
+
+GAFlightMetadataReader *
+gaflight_metadata_reader_new_raw(arrow::flight::FlightMetadataReader *flight_reader)
+{
+  return GAFLIGHT_METADATA_READER(
+    g_object_new(GAFLIGHT_TYPE_METADATA_READER, "reader", flight_reader, nullptr));
+}
+
+arrow::flight::FlightMetadataReader *
+gaflight_metadata_reader_get_raw(GAFlightMetadataReader *reader)
+{
+  auto priv = GAFLIGHT_METADATA_READER_GET_PRIVATE(reader);
+  return priv->reader;
+}
+
+arrow::flight::FlightCallOptions *
+gaflight_call_options_get_raw(GAFlightCallOptions *options)
+{
+  auto priv = GAFLIGHT_CALL_OPTIONS_GET_PRIVATE(options);
+  return &(priv->options);
+}
+
+arrow::flight::FlightClientOptions *
+gaflight_client_options_get_raw(GAFlightClientOptions *options)
+{
+  auto priv = GAFLIGHT_CLIENT_OPTIONS_GET_PRIVATE(options);
+  return &(priv->options);
+}
+
+GAFlightDoPutResult *
+gaflight_do_put_result_new_raw(arrow::flight::FlightClient::DoPutResult *flight_result)
+{
+  return GAFLIGHT_DO_PUT_RESULT(
+    g_object_new(GAFLIGHT_TYPE_DO_PUT_RESULT, "result", flight_result, nullptr));
+}
+
+std::shared_ptr<arrow::flight::FlightClient>
+gaflight_client_get_raw(GAFlightClient *client)
+{
+  auto priv = GAFLIGHT_CLIENT_GET_PRIVATE(client);
+  return priv->client;
+}
+
+GAFlightClient *
+gaflight_client_new_raw(std::shared_ptr<arrow::flight::FlightClient> *flight_client)
+{
+  return GAFLIGHT_CLIENT(
+    g_object_new(GAFLIGHT_TYPE_CLIENT, "client", flight_client, NULL));
+}

--- a/cpp/common.cpp
+++ b/cpp/common.cpp
@@ -1,0 +1,1536 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <arrow-glib/arrow-glib.hpp>
+
+#include <arrow-flight-glib/common.hpp>
+
+G_BEGIN_DECLS
+
+/**
+ * SECTION: common
+ * @section_id: common
+ * @title: Classes both for client and server
+ * @include: arrow-flight-glib/arrow-flight-glib.h
+ *
+ * #GAFlightCriteria is a class for criteria.
+ *
+ * #GAFlightLocation is a class for location.
+ *
+ * #GAFlightDescriptor is a base class for all descriptor classes such
+ * as #GAFlightPathDescriptor.
+ *
+ * #GAFlightPathDescriptor is a class for path descriptor.
+ *
+ * #GAFlightCommandDescriptor is a class for command descriptor.
+ *
+ * #GAFlightTicket is a class for ticket.
+ *
+ * #GAFlightEndpoint is a class for endpoint.
+ *
+ * #GAFlightInfo is a class for flight information.
+ *
+ * #GAFlightStreamChunk is a class for a chunk in stream.
+ *
+ * #GAFlightRecordBatchReader is an abstract class for reading record
+ * batches with metadata.
+ *
+ * #GAFlightRecordBatchWeriter is an abstract class for
+ * writing record batches with metadata.
+ *
+ * Since: 5.0.0
+ */
+
+/**
+ * GAFlightHeaderFunc:
+ * @name: A header name.
+ * @value: The value corresponding to the name.
+ * @user_data: User data passed to gaflight_call_options_foreach_header()
+ *   and so on.
+ *
+ * It is called with each header name/value pair, together with the
+ * @user_data parameter which is passed to
+ * gaflight_call_options_foreach_header() and so on.
+ *
+ * Since: 9.0.0
+ */
+
+typedef struct GAFlightCriteriaPrivate_
+{
+  arrow::flight::Criteria criteria;
+  GBytes *expression;
+} GAFlightCriteriaPrivate;
+
+enum {
+  PROP_EXPRESSION = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightCriteria, gaflight_criteria, G_TYPE_OBJECT)
+
+#define GAFLIGHT_CRITERIA_GET_PRIVATE(obj)                                               \
+  static_cast<GAFlightCriteriaPrivate *>(                                                \
+    gaflight_criteria_get_instance_private(GAFLIGHT_CRITERIA(obj)))
+
+static void
+gaflight_criteria_dispose(GObject *object)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(object);
+
+  if (priv->expression) {
+    g_bytes_unref(priv->expression);
+    priv->expression = NULL;
+  }
+
+  G_OBJECT_CLASS(gaflight_criteria_parent_class)->dispose(object);
+}
+
+static void
+gaflight_criteria_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(object);
+
+  priv->criteria.~Criteria();
+
+  G_OBJECT_CLASS(gaflight_criteria_parent_class)->finalize(object);
+}
+
+static void
+gaflight_criteria_set_property(GObject *object,
+                               guint prop_id,
+                               const GValue *value,
+                               GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_EXPRESSION:
+    if (priv->expression) {
+      g_bytes_unref(priv->expression);
+    }
+    priv->expression = static_cast<GBytes *>(g_value_dup_boxed(value));
+    {
+      gsize size;
+      auto data = g_bytes_get_data(priv->expression, &size);
+      priv->criteria.expression.assign(static_cast<const char *>(data), size);
+    }
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_criteria_get_property(GObject *object,
+                               guint prop_id,
+                               GValue *value,
+                               GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_EXPRESSION:
+    g_value_set_boxed(value, priv->expression);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_criteria_init(GAFlightCriteria *object)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(object);
+  new (&priv->criteria) arrow::flight::Criteria;
+}
+
+static void
+gaflight_criteria_class_init(GAFlightCriteriaClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = gaflight_criteria_dispose;
+  gobject_class->finalize = gaflight_criteria_finalize;
+  gobject_class->set_property = gaflight_criteria_set_property;
+  gobject_class->get_property = gaflight_criteria_get_property;
+
+  GParamSpec *spec;
+  /**
+   * GAFlightCriteria:expression:
+   *
+   * Opaque criteria expression, dependent on server implementation.
+   *
+   * Since: 5.0.0
+   */
+  spec = g_param_spec_boxed("expression",
+                            "Expression",
+                            "Opaque criteria expression, "
+                            "dependent on server implementation",
+                            G_TYPE_BYTES,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_EXPRESSION, spec);
+}
+
+/**
+ * gaflight_criteria_new:
+ * @expression: A #GBytes.
+ *
+ * Returns: The newly created #GAFlightCriteria, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GAFlightCriteria *
+gaflight_criteria_new(GBytes *expression)
+{
+  return GAFLIGHT_CRITERIA(
+    g_object_new(GAFLIGHT_TYPE_CRITERIA, "expression", expression, NULL));
+}
+
+typedef struct GAFlightLocationPrivate_
+{
+  arrow::flight::Location location;
+} GAFlightLocationPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightLocation, gaflight_location, G_TYPE_OBJECT)
+
+#define GAFLIGHT_LOCATION_GET_PRIVATE(obj)                                               \
+  static_cast<GAFlightLocationPrivate *>(                                                \
+    gaflight_location_get_instance_private(GAFLIGHT_LOCATION(obj)))
+
+static void
+gaflight_location_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_LOCATION_GET_PRIVATE(object);
+
+  priv->location.~Location();
+
+  G_OBJECT_CLASS(gaflight_location_parent_class)->finalize(object);
+}
+
+static void
+gaflight_location_init(GAFlightLocation *object)
+{
+  auto priv = GAFLIGHT_LOCATION_GET_PRIVATE(object);
+  new (&priv->location) arrow::flight::Location;
+}
+
+static void
+gaflight_location_class_init(GAFlightLocationClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_location_finalize;
+}
+
+/**
+ * gaflight_location_new:
+ * @uri: An URI to specify location.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable): The newly created location, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GAFlightLocation *
+gaflight_location_new(const gchar *uri, GError **error)
+{
+  auto location = GAFLIGHT_LOCATION(g_object_new(GAFLIGHT_TYPE_LOCATION, NULL));
+  auto flight_location = gaflight_location_get_raw(location);
+  if (garrow::check(error,
+                    arrow::flight::Location::Parse(uri).Value(flight_location),
+                    "[flight-location][new]")) {
+    return location;
+  } else {
+    g_object_unref(location);
+    return NULL;
+  }
+}
+
+/**
+ * gaflight_location_to_string:
+ * @location: A #GAFlightLocation.
+ *
+ * Returns: A representation of this URI as a string.
+ *
+ *   It should be freed with g_free() when no longer needed.
+ *
+ * Since: 5.0.0
+ */
+gchar *
+gaflight_location_to_string(GAFlightLocation *location)
+{
+  const auto flight_location = gaflight_location_get_raw(location);
+  const auto string = flight_location->ToString();
+  return g_strdup(string.c_str());
+}
+
+/**
+ * gaflight_location_get_scheme:
+ * @location: A #GAFlightLocation.
+ *
+ * Returns: The scheme of this URI.
+ *
+ *   It should be freed with g_free() when no longer needed.
+ *
+ * Since: 5.0.0
+ */
+gchar *
+gaflight_location_get_scheme(GAFlightLocation *location)
+{
+  const auto flight_location = gaflight_location_get_raw(location);
+  const auto scheme = flight_location->scheme();
+  return g_strdup(scheme.c_str());
+}
+
+/**
+ * gaflight_location_equal:
+ * @location: A #GAFlightLocation.
+ * @other_location: A #GAFlightLocation to be compared.
+ *
+ * Returns: %TRUE if both of them represents the same URI, %FALSE otherwise.
+ *
+ * Since: 5.0.0
+ */
+gboolean
+gaflight_location_equal(GAFlightLocation *location, GAFlightLocation *other_location)
+{
+  const auto flight_location = gaflight_location_get_raw(location);
+  const auto flight_other_location = gaflight_location_get_raw(other_location);
+  return flight_location->Equals(*flight_other_location);
+}
+
+typedef struct GAFlightDescriptorPrivate_
+{
+  arrow::flight::FlightDescriptor descriptor;
+} GAFlightDescriptorPrivate;
+
+enum {
+  PROP_DESCRIPTOR = 1,
+};
+
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(GAFlightDescriptor,
+                                    gaflight_descriptor,
+                                    G_TYPE_OBJECT)
+
+#define GAFLIGHT_DESCRIPTOR_GET_PRIVATE(obj)                                             \
+  static_cast<GAFlightDescriptorPrivate *>(                                              \
+    gaflight_descriptor_get_instance_private(GAFLIGHT_DESCRIPTOR(obj)))
+
+static void
+gaflight_descriptor_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_DESCRIPTOR_GET_PRIVATE(object);
+
+  priv->descriptor.~FlightDescriptor();
+
+  G_OBJECT_CLASS(gaflight_descriptor_parent_class)->finalize(object);
+}
+
+static void
+gaflight_descriptor_set_property(GObject *object,
+                                 guint prop_id,
+                                 const GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_DESCRIPTOR_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_DESCRIPTOR:
+    priv->descriptor =
+      *static_cast<arrow::flight::FlightDescriptor *>(g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_descriptor_init(GAFlightDescriptor *object)
+{
+  auto priv = GAFLIGHT_DESCRIPTOR_GET_PRIVATE(object);
+  new (&priv->descriptor) arrow::flight::FlightDescriptor;
+}
+
+static void
+gaflight_descriptor_class_init(GAFlightDescriptorClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_descriptor_finalize;
+  gobject_class->set_property = gaflight_descriptor_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "descriptor",
+    "Descriptor",
+    "The raw arrow::flight::FlightDescriptor",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_EXPRESSION, spec);
+}
+
+/**
+ * gaflight_descriptor_to_string:
+ * @descriptor: A #GAFlightDescriptor.
+ *
+ * Returns: A descriptor as a string.
+ *
+ *   It should be freed with g_free() when no longer needed.
+ *
+ * Since: 5.0.0
+ */
+gchar *
+gaflight_descriptor_to_string(GAFlightDescriptor *descriptor)
+{
+  const auto flight_descriptor = gaflight_descriptor_get_raw(descriptor);
+  const auto string = flight_descriptor->ToString();
+  return g_strdup(string.c_str());
+}
+
+/**
+ * gaflight_descriptor_equal:
+ * @descriptor: A #GAFlightDescriptor.
+ * @other_descriptor: A #GAFlightDescriptor to be compared.
+ *
+ * Returns: %TRUE if both of them represents the same descriptor,
+ *   %FALSE otherwise.
+ *
+ * Since: 5.0.0
+ */
+gboolean
+gaflight_descriptor_equal(GAFlightDescriptor *descriptor,
+                          GAFlightDescriptor *other_descriptor)
+{
+  const auto flight_descriptor = gaflight_descriptor_get_raw(descriptor);
+  const auto flight_other_descriptor = gaflight_descriptor_get_raw(other_descriptor);
+  return flight_descriptor->Equals(*flight_other_descriptor);
+}
+
+G_DEFINE_TYPE(GAFlightPathDescriptor, gaflight_path_descriptor, GAFLIGHT_TYPE_DESCRIPTOR)
+
+static void
+gaflight_path_descriptor_init(GAFlightPathDescriptor *object)
+{
+}
+
+static void
+gaflight_path_descriptor_class_init(GAFlightPathDescriptorClass *klass)
+{
+}
+
+/**
+ * gaflight_path_descriptor_new:
+ * @paths: (array length=n_paths): List of paths identifying a
+ *   particular dataset.
+ * @n_paths: The number of @paths.
+ *
+ * Returns: The newly created #GAFlightPathDescriptor.
+ *
+ * Since: 5.0.0
+ */
+GAFlightPathDescriptor *
+gaflight_path_descriptor_new(const gchar **paths, gsize n_paths)
+{
+  std::vector<std::string> flight_paths;
+  for (gsize i = 0; i < n_paths; i++) {
+    flight_paths.push_back(paths[i]);
+  }
+  auto flight_descriptor = arrow::flight::FlightDescriptor::Path(flight_paths);
+  return GAFLIGHT_PATH_DESCRIPTOR(gaflight_descriptor_new_raw(&flight_descriptor));
+}
+
+/**
+ * gaflight_path_descriptor_get_paths:
+ * @descriptor: A #GAFlightPathDescriptor.
+ *
+ * Returns: (nullable) (array zero-terminated=1) (transfer full):
+ *   The paths in this descriptor.
+ *
+ *   It must be freed with g_strfreev() when no longer needed.
+ *
+ * Since: 5.0.0
+ */
+gchar **
+gaflight_path_descriptor_get_paths(GAFlightPathDescriptor *descriptor)
+{
+  const auto flight_descriptor =
+    gaflight_descriptor_get_raw(GAFLIGHT_DESCRIPTOR(descriptor));
+  const auto &flight_paths = flight_descriptor->path;
+  if (flight_paths.empty()) {
+    return NULL;
+  } else {
+    auto paths = g_new(gchar *, flight_paths.size() + 1);
+    gsize i = 0;
+    for (const auto &flight_path : flight_paths) {
+      paths[i++] = g_strdup(flight_path.c_str());
+    }
+    paths[i] = NULL;
+    return paths;
+  }
+}
+
+G_DEFINE_TYPE(GAFlightCommandDescriptor,
+              gaflight_command_descriptor,
+              GAFLIGHT_TYPE_DESCRIPTOR)
+
+static void
+gaflight_command_descriptor_init(GAFlightCommandDescriptor *object)
+{
+}
+
+static void
+gaflight_command_descriptor_class_init(GAFlightCommandDescriptorClass *klass)
+{
+}
+
+/**
+ * gaflight_command_descriptor_new:
+ * @command: Opaque value used to express a command.
+ *
+ * Returns: The newly created #GAFlightCommandDescriptor.
+ *
+ * Since: 5.0.0
+ */
+GAFlightCommandDescriptor *
+gaflight_command_descriptor_new(const gchar *command)
+{
+  auto flight_descriptor = arrow::flight::FlightDescriptor::Command(command);
+  return GAFLIGHT_COMMAND_DESCRIPTOR(gaflight_descriptor_new_raw(&flight_descriptor));
+}
+
+/**
+ * gaflight_command_descriptor_get_command:
+ * @descriptor: A #GAFlightCommandDescriptor.
+ *
+ * Returns: The opaque value used to express a command.
+ *
+ *   It should be freed with g_free() when no longer needed.
+ *
+ * Since: 5.0.0
+ */
+gchar *
+gaflight_command_descriptor_get_command(GAFlightCommandDescriptor *descriptor)
+{
+  const auto flight_descriptor =
+    gaflight_descriptor_get_raw(GAFLIGHT_DESCRIPTOR(descriptor));
+  const auto &flight_command = flight_descriptor->cmd;
+  return g_strdup(flight_command.c_str());
+}
+
+typedef struct GAFlightTicketPrivate_
+{
+  arrow::flight::Ticket ticket;
+  GBytes *data;
+} GAFlightTicketPrivate;
+
+enum {
+  PROP_DATA = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightTicket, gaflight_ticket, G_TYPE_OBJECT)
+
+#define GAFLIGHT_TICKET_GET_PRIVATE(obj)                                                 \
+  static_cast<GAFlightTicketPrivate *>(                                                  \
+    gaflight_ticket_get_instance_private(GAFLIGHT_TICKET(obj)))
+
+static void
+gaflight_ticket_dispose(GObject *object)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(object);
+
+  if (priv->data) {
+    g_bytes_unref(priv->data);
+    priv->data = NULL;
+  }
+
+  G_OBJECT_CLASS(gaflight_ticket_parent_class)->dispose(object);
+}
+
+static void
+gaflight_ticket_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(object);
+
+  priv->ticket.~Ticket();
+
+  G_OBJECT_CLASS(gaflight_ticket_parent_class)->finalize(object);
+}
+
+static void
+gaflight_ticket_set_property(GObject *object,
+                             guint prop_id,
+                             const GValue *value,
+                             GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_DATA:
+    if (priv->data) {
+      g_bytes_unref(priv->data);
+    }
+    priv->data = static_cast<GBytes *>(g_value_dup_boxed(value));
+    {
+      gsize size;
+      auto data = g_bytes_get_data(priv->data, &size);
+      priv->ticket.ticket.assign(static_cast<const char *>(data), size);
+    }
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_ticket_get_property(GObject *object,
+                             guint prop_id,
+                             GValue *value,
+                             GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_DATA:
+    g_value_set_boxed(value, priv->data);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_ticket_init(GAFlightTicket *object)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(object);
+  new (&priv->ticket) arrow::flight::Ticket;
+}
+
+static void
+gaflight_ticket_class_init(GAFlightTicketClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = gaflight_ticket_dispose;
+  gobject_class->finalize = gaflight_ticket_finalize;
+  gobject_class->set_property = gaflight_ticket_set_property;
+  gobject_class->get_property = gaflight_ticket_get_property;
+
+  GParamSpec *spec;
+  /**
+   * GAFlightTicket:data:
+   *
+   * Opaque identifier or credential to use when requesting a data
+   * stream with the DoGet RPC.
+   *
+   * Since: 5.0.0
+   */
+  spec = g_param_spec_boxed("data",
+                            "Data",
+                            "Opaque identifier or credential to use "
+                            "when requesting a data stream with the DoGet RPC",
+                            G_TYPE_BYTES,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_DATA, spec);
+}
+
+/**
+ * gaflight_ticket_new:
+ * @data: A #GBytes.
+ *
+ * Returns: The newly created #GAFlightTicket, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GAFlightTicket *
+gaflight_ticket_new(GBytes *data)
+{
+  return GAFLIGHT_TICKET(g_object_new(GAFLIGHT_TYPE_TICKET, "data", data, NULL));
+}
+
+/**
+ * gaflight_ticket_equal:
+ * @ticket: A #GAFlightTicket.
+ * @other_ticket: A #GAFlightTicket to be compared.
+ *
+ * Returns: %TRUE if both of them represents the same ticket, %FALSE otherwise.
+ *
+ * Since: 5.0.0
+ */
+gboolean
+gaflight_ticket_equal(GAFlightTicket *ticket, GAFlightTicket *other_ticket)
+{
+  const auto flight_ticket = gaflight_ticket_get_raw(ticket);
+  const auto flight_other_ticket = gaflight_ticket_get_raw(other_ticket);
+  return flight_ticket->Equals(*flight_other_ticket);
+}
+
+typedef struct GAFlightEndpointPrivate_
+{
+  arrow::flight::FlightEndpoint endpoint;
+  GAFlightTicket *ticket;
+  GList *locations;
+} GAFlightEndpointPrivate;
+
+enum {
+  PROP_TICKET = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightEndpoint, gaflight_endpoint, G_TYPE_OBJECT)
+
+#define GAFLIGHT_ENDPOINT_GET_PRIVATE(obj)                                               \
+  static_cast<GAFlightEndpointPrivate *>(                                                \
+    gaflight_endpoint_get_instance_private(GAFLIGHT_ENDPOINT(obj)))
+
+static void
+gaflight_endpoint_dispose(GObject *object)
+{
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(object);
+
+  if (priv->ticket) {
+    g_object_unref(priv->ticket);
+    priv->ticket = NULL;
+  }
+
+  if (priv->locations) {
+    g_list_free_full(priv->locations, g_object_unref);
+    priv->locations = NULL;
+  }
+
+  G_OBJECT_CLASS(gaflight_endpoint_parent_class)->dispose(object);
+}
+
+static void
+gaflight_endpoint_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(object);
+
+  priv->endpoint.~FlightEndpoint();
+
+  G_OBJECT_CLASS(gaflight_endpoint_parent_class)->finalize(object);
+}
+
+static void
+gaflight_endpoint_get_property(GObject *object,
+                               guint prop_id,
+                               GValue *value,
+                               GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_TICKET:
+    g_value_set_object(value, priv->ticket);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_endpoint_init(GAFlightEndpoint *object)
+{
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(object);
+  new (&priv->endpoint) arrow::flight::FlightEndpoint;
+}
+
+static void
+gaflight_endpoint_class_init(GAFlightEndpointClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = gaflight_endpoint_dispose;
+  gobject_class->finalize = gaflight_endpoint_finalize;
+  gobject_class->get_property = gaflight_endpoint_get_property;
+
+  GParamSpec *spec;
+  /**
+   * GAFlightEndpoint:ticket:
+   *
+   * Opaque ticket identify; use with DoGet RPC.
+   *
+   * Since: 5.0.0
+   */
+  spec = g_param_spec_object("ticket",
+                             "Ticket",
+                             "Opaque ticket identify; use with DoGet RPC",
+                             GAFLIGHT_TYPE_TICKET,
+                             static_cast<GParamFlags>(G_PARAM_READABLE));
+  g_object_class_install_property(gobject_class, PROP_TICKET, spec);
+}
+
+/**
+ * gaflight_endpoint_new:
+ * @ticket: A #GAFlightTicket.
+ * @locations: (element-type GAFlightLocation): A list of #GAFlightLocation.
+ *
+ * Returns: The newly created #GAFlightEndpoint, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GAFlightEndpoint *
+gaflight_endpoint_new(GAFlightTicket *ticket, GList *locations)
+{
+  auto endpoint = gaflight_endpoint_new_raw(nullptr, ticket);
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(endpoint);
+  for (auto node = locations; node; node = node->next) {
+    auto location = GAFLIGHT_LOCATION(node->data);
+    priv->endpoint.locations.push_back(*gaflight_location_get_raw(location));
+  }
+  return endpoint;
+}
+
+/**
+ * gaflight_endpoint_equal:
+ * @endpoint: A #GAFlightEndpoint.
+ * @other_endpoint: A #GAFlightEndpoint to be compared.
+ *
+ * Returns: %TRUE if both of them represents the same endpoint,
+ *   %FALSE otherwise.
+ *
+ * Since: 5.0.0
+ */
+gboolean
+gaflight_endpoint_equal(GAFlightEndpoint *endpoint, GAFlightEndpoint *other_endpoint)
+{
+  const auto flight_endpoint = gaflight_endpoint_get_raw(endpoint);
+  const auto flight_other_endpoint = gaflight_endpoint_get_raw(other_endpoint);
+  return flight_endpoint->Equals(*flight_other_endpoint);
+}
+
+/**
+ * gaflight_endpoint_get_locations:
+ * @endpoint: A #GAFlightEndpoint.
+ *
+ * Returns: (nullable) (element-type GAFlightLocation) (transfer full):
+ *   The locations in this endpoint.
+ *
+ *   It must be freed with g_list_free() and g_object_unref() when no
+ *   longer needed. You can use `g_list_free_full(locations,
+ *   g_object_unref)`.
+ *
+ * Since: 5.0.0
+ */
+GList *
+gaflight_endpoint_get_locations(GAFlightEndpoint *endpoint)
+{
+  const auto flight_endpoint = gaflight_endpoint_get_raw(endpoint);
+  GList *locations = NULL;
+  for (const auto &flight_location : flight_endpoint->locations) {
+    auto location = gaflight_location_new(flight_location.ToString().c_str(), nullptr);
+    locations = g_list_prepend(locations, location);
+  }
+  return g_list_reverse(locations);
+}
+
+typedef struct GAFlightInfoPrivate_
+{
+  arrow::flight::FlightInfo info;
+} GAFlightInfoPrivate;
+
+enum {
+  PROP_INFO = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightInfo, gaflight_info, G_TYPE_OBJECT)
+
+#define GAFLIGHT_INFO_GET_PRIVATE(obj)                                                   \
+  static_cast<GAFlightInfoPrivate *>(                                                    \
+    gaflight_info_get_instance_private(GAFLIGHT_INFO(obj)))
+
+static void
+gaflight_info_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_INFO_GET_PRIVATE(object);
+
+  priv->info.~FlightInfo();
+
+  G_OBJECT_CLASS(gaflight_info_parent_class)->finalize(object);
+}
+
+static void
+gaflight_info_set_property(GObject *object,
+                           guint prop_id,
+                           const GValue *value,
+                           GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_INFO_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_INFO:
+    {
+      auto info = static_cast<arrow::flight::FlightInfo *>(g_value_get_pointer(value));
+      new (&(priv->info)) arrow::flight::FlightInfo(*info);
+    }
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_info_init(GAFlightInfo *object)
+{
+}
+
+static void
+gaflight_info_class_init(GAFlightInfoClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_info_finalize;
+  gobject_class->set_property = gaflight_info_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "info",
+    "Info",
+    "The raw arrow::flight::FlightInfo *",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_INFO, spec);
+}
+
+/**
+ * gaflight_info_new:
+ * @schema: A #GArrowSchema.
+ * @descriptor: A #GAFlightDescriptor.
+ * @endpoints: (element-type GAFlightEndpoint): A list of #GAFlightEndpoint.
+ * @total_records: The number of total records.
+ * @total_bytes: The number of total bytes.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable): The newly created #GAFlightInfo, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GAFlightInfo *
+gaflight_info_new(GArrowSchema *schema,
+                  GAFlightDescriptor *descriptor,
+                  GList *endpoints,
+                  gint64 total_records,
+                  gint64 total_bytes,
+                  GError **error)
+{
+  auto arrow_schema = garrow_schema_get_raw(schema);
+  auto flight_descriptor = gaflight_descriptor_get_raw(descriptor);
+  std::vector<arrow::flight::FlightEndpoint> flight_endpoints;
+  for (auto node = endpoints; node; node = node->next) {
+    auto endpoint = GAFLIGHT_ENDPOINT(node->data);
+    flight_endpoints.push_back(*gaflight_endpoint_get_raw(endpoint));
+  }
+  auto flight_info_result = arrow::flight::FlightInfo::Make(*arrow_schema,
+                                                            *flight_descriptor,
+                                                            flight_endpoints,
+                                                            total_records,
+                                                            total_bytes);
+  if (!garrow::check(error, flight_info_result, "[flight-info][new]")) {
+    return NULL;
+  }
+  return gaflight_info_new_raw(&(*flight_info_result));
+}
+
+/**
+ * gaflight_info_equal:
+ * @info: A #GAFlightInfo.
+ * @other_info: A #GAFlightInfo to be compared.
+ *
+ * Returns: %TRUE if both of them represents the same information,
+ *   %FALSE otherwise.
+ *
+ * Since: 5.0.0
+ */
+gboolean
+gaflight_info_equal(GAFlightInfo *info, GAFlightInfo *other_info)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  const auto flight_other_info = gaflight_info_get_raw(other_info);
+  return (flight_info->serialized_schema() == flight_other_info->serialized_schema()) &&
+         (flight_info->descriptor() == flight_other_info->descriptor()) &&
+         (flight_info->endpoints() == flight_other_info->endpoints()) &&
+         (flight_info->total_records() == flight_other_info->total_records()) &&
+         (flight_info->total_bytes() == flight_other_info->total_bytes());
+}
+
+/**
+ * gaflight_info_get_schema:
+ * @info: A #GAFlightInfo.
+ * @options: (nullable): A #GArrowReadOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): Deserialized #GArrowSchema, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GArrowSchema *
+gaflight_info_get_schema(GAFlightInfo *info, GArrowReadOptions *options, GError **error)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  arrow::Status status;
+  std::shared_ptr<arrow::Schema> arrow_schema;
+  if (options) {
+    auto arrow_memo = garrow_read_options_get_dictionary_memo_raw(options);
+    status = flight_info->GetSchema(arrow_memo).Value(&arrow_schema);
+  } else {
+    arrow::ipc::DictionaryMemo arrow_memo;
+    status = flight_info->GetSchema(&arrow_memo).Value(&arrow_schema);
+  }
+  if (garrow::check(error, status, "[flight-info][get-schema]")) {
+    return garrow_schema_new_raw(&arrow_schema);
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * gaflight_info_get_descriptor:
+ * @info: A #GAFlightInfo.
+ *
+ * Returns: (transfer full): The #GAFlightDescriptor of the information.
+ *
+ * Since: 5.0.0
+ */
+GAFlightDescriptor *
+gaflight_info_get_descriptor(GAFlightInfo *info)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  return gaflight_descriptor_new_raw(&(flight_info->descriptor()));
+}
+
+/**
+ * gaflight_info_get_endpoints:
+ * @info: A #GAFlightInfo.
+ *
+ * Returns: (element-type GAFlightEndpoint) (transfer full):
+ *   The list of #GAFlightEndpoint of the information.
+ *
+ * Since: 5.0.0
+ */
+GList *
+gaflight_info_get_endpoints(GAFlightInfo *info)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  GList *endpoints = NULL;
+  for (const auto &flight_endpoint : flight_info->endpoints()) {
+    auto endpoint = gaflight_endpoint_new_raw(&flight_endpoint, nullptr);
+    endpoints = g_list_prepend(endpoints, endpoint);
+  }
+  return g_list_reverse(endpoints);
+}
+
+/**
+ * gaflight_info_get_total_records:
+ * @info: A #GAFlightInfo.
+ *
+ * Returns: The number of total records of the information.
+ *
+ * Since: 5.0.0
+ */
+gint64
+gaflight_info_get_total_records(GAFlightInfo *info)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  return flight_info->total_records();
+}
+
+/**
+ * gaflight_info_get_total_bytes:
+ * @info: A #GAFlightInfo.
+ *
+ * Returns: The number of total bytes of the information.
+ *
+ * Since: 5.0.0
+ */
+gint64
+gaflight_info_get_total_bytes(GAFlightInfo *info)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  return flight_info->total_bytes();
+}
+
+typedef struct GAFlightStreamChunkPrivate_
+{
+  arrow::flight::FlightStreamChunk chunk;
+} GAFlightStreamChunkPrivate;
+
+enum {
+  PROP_CHUNK = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightStreamChunk, gaflight_stream_chunk, G_TYPE_OBJECT)
+
+#define GAFLIGHT_STREAM_CHUNK_GET_PRIVATE(obj)                                           \
+  static_cast<GAFlightStreamChunkPrivate *>(                                             \
+    gaflight_stream_chunk_get_instance_private(GAFLIGHT_STREAM_CHUNK(obj)))
+
+static void
+gaflight_stream_chunk_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_STREAM_CHUNK_GET_PRIVATE(object);
+
+  priv->chunk.~FlightStreamChunk();
+
+  G_OBJECT_CLASS(gaflight_info_parent_class)->finalize(object);
+}
+
+static void
+gaflight_stream_chunk_set_property(GObject *object,
+                                   guint prop_id,
+                                   const GValue *value,
+                                   GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_STREAM_CHUNK_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_CHUNK:
+    priv->chunk =
+      *static_cast<arrow::flight::FlightStreamChunk *>(g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_stream_chunk_init(GAFlightStreamChunk *object)
+{
+}
+
+static void
+gaflight_stream_chunk_class_init(GAFlightStreamChunkClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_stream_chunk_finalize;
+  gobject_class->set_property = gaflight_stream_chunk_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "chunk",
+    "Stream chunk",
+    "The raw arrow::flight::FlightStreamChunk *",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_CHUNK, spec);
+}
+
+/**
+ * gaflight_stream_chunk_get_data:
+ * @chunk: A #GAFlightStreamChunk.
+ *
+ * Returns: (transfer full): The data of the chunk.
+ *
+ * Since: 6.0.0
+ */
+GArrowRecordBatch *
+gaflight_stream_chunk_get_data(GAFlightStreamChunk *chunk)
+{
+  auto flight_chunk = gaflight_stream_chunk_get_raw(chunk);
+  return garrow_record_batch_new_raw(&(flight_chunk->data));
+}
+
+/**
+ * gaflight_stream_chunk_get_metadata:
+ * @chunk: A #GAFlightStreamChunk.
+ *
+ * Returns: (nullable) (transfer full): The metadata of the chunk.
+ *
+ *   The metadata may be NULL.
+ *
+ * Since: 6.0.0
+ */
+GArrowBuffer *
+gaflight_stream_chunk_get_metadata(GAFlightStreamChunk *chunk)
+{
+  auto flight_chunk = gaflight_stream_chunk_get_raw(chunk);
+  if (flight_chunk->app_metadata) {
+    return garrow_buffer_new_raw(&(flight_chunk->app_metadata));
+  } else {
+    return NULL;
+  }
+}
+
+typedef struct GAFlightRecordBatchReaderPrivate_
+{
+  arrow::flight::MetadataRecordBatchReader *reader;
+  bool is_owner;
+} GAFlightRecordBatchReaderPrivate;
+
+enum {
+  PROP_RECORD_BATCH_READER_READER = 1,
+  PROP_RECORD_BATCH_READER_IS_OWNER,
+};
+
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(GAFlightRecordBatchReader,
+                                    gaflight_record_batch_reader,
+                                    G_TYPE_OBJECT)
+
+#define GAFLIGHT_RECORD_BATCH_READER_GET_PRIVATE(obj)                                    \
+  static_cast<GAFlightRecordBatchReaderPrivate *>(                                       \
+    gaflight_record_batch_reader_get_instance_private(                                   \
+      GAFLIGHT_RECORD_BATCH_READER(obj)))
+
+static void
+gaflight_record_batch_reader_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_RECORD_BATCH_READER_GET_PRIVATE(object);
+  if (priv->is_owner) {
+    delete priv->reader;
+  }
+  G_OBJECT_CLASS(gaflight_record_batch_reader_parent_class)->finalize(object);
+}
+
+static void
+gaflight_record_batch_reader_set_property(GObject *object,
+                                          guint prop_id,
+                                          const GValue *value,
+                                          GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_RECORD_BATCH_READER_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_RECORD_BATCH_READER_READER:
+    priv->reader =
+      static_cast<arrow::flight::MetadataRecordBatchReader *>(g_value_get_pointer(value));
+    break;
+  case PROP_RECORD_BATCH_READER_IS_OWNER:
+    priv->is_owner = g_value_get_boolean(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_record_batch_reader_init(GAFlightRecordBatchReader *object)
+{
+}
+
+static void
+gaflight_record_batch_reader_class_init(GAFlightRecordBatchReaderClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_record_batch_reader_finalize;
+  gobject_class->set_property = gaflight_record_batch_reader_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "reader",
+    nullptr,
+    nullptr,
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_RECORD_BATCH_READER_READER, spec);
+
+  spec = g_param_spec_boolean(
+    "is-owner",
+    nullptr,
+    nullptr,
+    TRUE,
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_RECORD_BATCH_READER_IS_OWNER, spec);
+}
+
+/**
+ * gaflight_record_batch_reader_read_next:
+ * @reader: A #GAFlightRecordBatchReader.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): The next chunk on success, %NULL on end
+ *   of stream, %NULL on error.
+ *
+ * Since: 6.0.0
+ */
+GAFlightStreamChunk *
+gaflight_record_batch_reader_read_next(GAFlightRecordBatchReader *reader, GError **error)
+{
+  auto flight_reader = gaflight_record_batch_reader_get_raw(reader);
+  arrow::flight::FlightStreamChunk flight_chunk;
+  auto status = flight_reader->Next().Value(&flight_chunk);
+  if (garrow::check(error, status, "[flight-record-batch-reader][read-next]")) {
+    if (flight_chunk.data) {
+      return gaflight_stream_chunk_new_raw(&flight_chunk);
+    } else {
+      return NULL;
+    }
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * gaflight_record_batch_reader_read_all:
+ * @reader: A #GAFlightRecordBatchReader.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): The all data on success, %NULL on error.
+ *
+ * Since: 6.0.0
+ */
+GArrowTable *
+gaflight_record_batch_reader_read_all(GAFlightRecordBatchReader *reader, GError **error)
+{
+  auto flight_reader = gaflight_record_batch_reader_get_raw(reader);
+  std::shared_ptr<arrow::Table> arrow_table;
+  auto status = flight_reader->ToTable().Value(&arrow_table);
+  if (garrow::check(error, status, "[flight-record-batch-reader][read-all]")) {
+    return garrow_table_new_raw(&arrow_table);
+  } else {
+    return NULL;
+  }
+}
+
+G_DEFINE_ABSTRACT_TYPE(GAFlightRecordBatchWriter,
+                       gaflight_record_batch_writer,
+                       GARROW_TYPE_RECORD_BATCH_WRITER)
+
+static void
+gaflight_record_batch_writer_init(GAFlightRecordBatchWriter *object)
+{
+}
+
+static void
+gaflight_record_batch_writer_class_init(GAFlightRecordBatchWriterClass *klass)
+{
+}
+
+/**
+ * gaflight_record_batch_writer_begin:
+ * @writer: A #GAFlightRecordBatchWriter.
+ * @schema: A #GArrowSchema.
+ * @options: (nullable): A #GArrowWriteOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Begins writing data with the given schema. Only used with
+ * `DoExchange`.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 18.0.0
+ */
+gboolean
+gaflight_record_batch_writer_begin(GAFlightRecordBatchWriter *writer,
+                                   GArrowSchema *schema,
+                                   GArrowWriteOptions *options,
+                                   GError **error)
+{
+  auto flight_writer = std::static_pointer_cast<arrow::flight::MetadataRecordBatchWriter>(
+    garrow_record_batch_writer_get_raw(GARROW_RECORD_BATCH_WRITER(writer)));
+  auto arrow_schema = garrow_schema_get_raw(schema);
+  arrow::ipc::IpcWriteOptions arrow_write_options;
+  if (options) {
+    arrow_write_options = *garrow_write_options_get_raw(options);
+  } else {
+    arrow_write_options = arrow::ipc::IpcWriteOptions::Defaults();
+  }
+  return garrow::check(error,
+                       flight_writer->Begin(arrow_schema, arrow_write_options),
+                       "[flight-record-batch-writer][begin]");
+}
+
+/**
+ * gaflight_record_batch_writer_write_metadata:
+ * @writer: A #GAFlightRecordBatchWriter.
+ * @metadata: A #GArrowBuffer.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Write metadata.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 18.0.0
+ */
+gboolean
+gaflight_record_batch_writer_write_metadata(GAFlightRecordBatchWriter *writer,
+                                            GArrowBuffer *metadata,
+                                            GError **error)
+{
+  auto flight_writer = std::static_pointer_cast<arrow::flight::MetadataRecordBatchWriter>(
+    garrow_record_batch_writer_get_raw(GARROW_RECORD_BATCH_WRITER(writer)));
+  auto arrow_metadata = garrow_buffer_get_raw(metadata);
+  return garrow::check(error,
+                       flight_writer->WriteMetadata(arrow_metadata),
+                       "[flight-record-batch-writer][write-metadata]");
+}
+
+/**
+ * gaflight_record_batch_writer_write_record_batch:
+ * @writer: A #GAFlightRecordBatchWriter.
+ * @record_batch: A #GArrowRecordBatch.
+ * @metadata: (nullable): A #GArrowBuffer.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Write a record batch with metadata.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 18.0.0
+ */
+gboolean
+gaflight_record_batch_writer_write_record_batch(GAFlightRecordBatchWriter *writer,
+                                                GArrowRecordBatch *record_batch,
+                                                GArrowBuffer *metadata,
+                                                GError **error)
+{
+  auto flight_writer = std::static_pointer_cast<arrow::flight::MetadataRecordBatchWriter>(
+    garrow_record_batch_writer_get_raw(GARROW_RECORD_BATCH_WRITER(writer)));
+  auto arrow_record_batch = garrow_record_batch_get_raw(record_batch);
+  auto arrow_metadata = garrow_buffer_get_raw(metadata);
+  return garrow::check(
+    error,
+    flight_writer->WriteWithMetadata(*arrow_record_batch, arrow_metadata),
+    "[flight-record-batch-writer][write]");
+}
+
+G_END_DECLS
+
+GAFlightCriteria *
+gaflight_criteria_new_raw(const arrow::flight::Criteria *flight_criteria)
+{
+  auto criteria = g_object_new(GAFLIGHT_TYPE_CRITERIA, NULL);
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(criteria);
+  priv->criteria = *flight_criteria;
+  priv->expression =
+    g_bytes_new(priv->criteria.expression.data(), priv->criteria.expression.size());
+  return GAFLIGHT_CRITERIA(criteria);
+}
+
+arrow::flight::Criteria *
+gaflight_criteria_get_raw(GAFlightCriteria *criteria)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(criteria);
+  return &(priv->criteria);
+}
+
+arrow::flight::Location *
+gaflight_location_get_raw(GAFlightLocation *location)
+{
+  auto priv = GAFLIGHT_LOCATION_GET_PRIVATE(location);
+  return &(priv->location);
+}
+
+GAFlightDescriptor *
+gaflight_descriptor_new_raw(const arrow::flight::FlightDescriptor *flight_descriptor)
+{
+  GType gtype = GAFLIGHT_TYPE_DESCRIPTOR;
+  switch (flight_descriptor->type) {
+  case arrow::flight::FlightDescriptor::DescriptorType::PATH:
+    gtype = GAFLIGHT_TYPE_PATH_DESCRIPTOR;
+    break;
+  case arrow::flight::FlightDescriptor::DescriptorType::CMD:
+    gtype = GAFLIGHT_TYPE_COMMAND_DESCRIPTOR;
+    break;
+  default:
+    break;
+  }
+  return GAFLIGHT_DESCRIPTOR(g_object_new(gtype, "descriptor", flight_descriptor, NULL));
+}
+
+arrow::flight::FlightDescriptor *
+gaflight_descriptor_get_raw(GAFlightDescriptor *descriptor)
+{
+  auto priv = GAFLIGHT_DESCRIPTOR_GET_PRIVATE(descriptor);
+  return &(priv->descriptor);
+}
+
+GAFlightTicket *
+gaflight_ticket_new_raw(const arrow::flight::Ticket *flight_ticket)
+{
+  auto ticket = g_object_new(GAFLIGHT_TYPE_TICKET, NULL);
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(ticket);
+  priv->ticket = *flight_ticket;
+  priv->data = g_bytes_new(priv->ticket.ticket.data(), priv->ticket.ticket.size());
+  return GAFLIGHT_TICKET(ticket);
+}
+
+arrow::flight::Ticket *
+gaflight_ticket_get_raw(GAFlightTicket *ticket)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(ticket);
+  return &(priv->ticket);
+}
+
+GAFlightEndpoint *
+gaflight_endpoint_new_raw(const arrow::flight::FlightEndpoint *flight_endpoint,
+                          GAFlightTicket *ticket)
+{
+  auto endpoint = GAFLIGHT_ENDPOINT(g_object_new(GAFLIGHT_TYPE_ENDPOINT, NULL));
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(endpoint);
+  if (ticket) {
+    priv->ticket = ticket;
+    g_object_ref(priv->ticket);
+    priv->endpoint.ticket = *gaflight_ticket_get_raw(priv->ticket);
+  } else {
+    auto data = g_bytes_new(flight_endpoint->ticket.ticket.data(),
+                            flight_endpoint->ticket.ticket.length());
+    auto ticket = gaflight_ticket_new(data);
+    g_bytes_unref(data);
+    priv->ticket = ticket;
+    priv->endpoint.ticket.ticket = flight_endpoint->ticket.ticket;
+  }
+  if (flight_endpoint) {
+    priv->endpoint.locations = flight_endpoint->locations;
+  }
+  return endpoint;
+}
+
+arrow::flight::FlightEndpoint *
+gaflight_endpoint_get_raw(GAFlightEndpoint *endpoint)
+{
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(endpoint);
+  return &(priv->endpoint);
+}
+
+GAFlightInfo *
+gaflight_info_new_raw(arrow::flight::FlightInfo *flight_info)
+{
+  return GAFLIGHT_INFO(g_object_new(GAFLIGHT_TYPE_INFO, "info", flight_info, NULL));
+}
+
+arrow::flight::FlightInfo *
+gaflight_info_get_raw(GAFlightInfo *info)
+{
+  auto priv = GAFLIGHT_INFO_GET_PRIVATE(info);
+  return &(priv->info);
+}
+
+GAFlightStreamChunk *
+gaflight_stream_chunk_new_raw(arrow::flight::FlightStreamChunk *flight_chunk)
+{
+  return GAFLIGHT_STREAM_CHUNK(
+    g_object_new(GAFLIGHT_TYPE_STREAM_CHUNK, "chunk", flight_chunk, NULL));
+}
+
+arrow::flight::FlightStreamChunk *
+gaflight_stream_chunk_get_raw(GAFlightStreamChunk *chunk)
+{
+  auto priv = GAFLIGHT_STREAM_CHUNK_GET_PRIVATE(chunk);
+  return &(priv->chunk);
+}
+
+arrow::flight::MetadataRecordBatchReader *
+gaflight_record_batch_reader_get_raw(GAFlightRecordBatchReader *reader)
+{
+  auto priv = GAFLIGHT_RECORD_BATCH_READER_GET_PRIVATE(reader);
+  return priv->reader;
+}

--- a/cpp/common_1.cpp
+++ b/cpp/common_1.cpp
@@ -1,0 +1,1536 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <arrow-glib/arrow-glib.hpp>
+
+#include <arrow-flight-glib/common.hpp>
+
+G_BEGIN_DECLS
+
+/**
+ * SECTION: common
+ * @section_id: common
+ * @title: Classes both for client and server
+ * @include: arrow-flight-glib/arrow-flight-glib.h
+ *
+ * #GAFlightCriteria is a class for criteria.
+ *
+ * #GAFlightLocation is a class for location.
+ *
+ * #GAFlightDescriptor is a base class for all descriptor classes such
+ * as #GAFlightPathDescriptor.
+ *
+ * #GAFlightPathDescriptor is a class for path descriptor.
+ *
+ * #GAFlightCommandDescriptor is a class for command descriptor.
+ *
+ * #GAFlightTicket is a class for ticket.
+ *
+ * #GAFlightEndpoint is a class for endpoint.
+ *
+ * #GAFlightInfo is a class for flight information.
+ *
+ * #GAFlightStreamChunk is a class for a chunk in stream.
+ *
+ * #GAFlightRecordBatchReader is an abstract class for reading record
+ * batches with metadata.
+ *
+ * #GAFlightRecordBatchWeriter is an abstract class for
+ * writing record batches with metadata.
+ *
+ * Since: 5.0.0
+ */
+
+/**
+ * GAFlightHeaderFunc:
+ * @name: A header name.
+ * @value: The value corresponding to the name.
+ * @user_data: User data passed to gaflight_call_options_foreach_header()
+ *   and so on.
+ *
+ * It is called with each header name/value pair, together with the
+ * @user_data parameter which is passed to
+ * gaflight_call_options_foreach_header() and so on.
+ *
+ * Since: 9.0.0
+ */
+
+typedef struct GAFlightCriteriaPrivate_
+{
+  arrow::flight::Criteria criteria;
+  GBytes *expression;
+} GAFlightCriteriaPrivate;
+
+enum {
+  PROP_EXPRESSION = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightCriteria, gaflight_criteria, G_TYPE_OBJECT)
+
+#define GAFLIGHT_CRITERIA_GET_PRIVATE(obj)                                               \
+  static_cast<GAFlightCriteriaPrivate *>(                                                \
+    gaflight_criteria_get_instance_private(GAFLIGHT_CRITERIA(obj)))
+
+static void
+gaflight_criteria_dispose(GObject *object)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(object);
+
+  if (priv->expression) {
+    g_bytes_unref(priv->expression);
+    priv->expression = NULL;
+  }
+
+  G_OBJECT_CLASS(gaflight_criteria_parent_class)->dispose(object);
+}
+
+static void
+gaflight_criteria_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(object);
+
+  priv->criteria.~Criteria();
+
+  G_OBJECT_CLASS(gaflight_criteria_parent_class)->finalize(object);
+}
+
+static void
+gaflight_criteria_set_property(GObject *object,
+                               guint prop_id,
+                               const GValue *value,
+                               GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_EXPRESSION:
+    if (priv->expression) {
+      g_bytes_unref(priv->expression);
+    }
+    priv->expression = static_cast<GBytes *>(g_value_dup_boxed(value));
+    {
+      gsize size;
+      auto data = g_bytes_get_data(priv->expression, &size);
+      priv->criteria.expression.assign(static_cast<const char *>(data), size);
+    }
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_criteria_get_property(GObject *object,
+                               guint prop_id,
+                               GValue *value,
+                               GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_EXPRESSION:
+    g_value_set_boxed(value, priv->expression);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_criteria_init(GAFlightCriteria *object)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(object);
+  new (&priv->criteria) arrow::flight::Criteria;
+}
+
+static void
+gaflight_criteria_class_init(GAFlightCriteriaClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = gaflight_criteria_dispose;
+  gobject_class->finalize = gaflight_criteria_finalize;
+  gobject_class->set_property = gaflight_criteria_set_property;
+  gobject_class->get_property = gaflight_criteria_get_property;
+
+  GParamSpec *spec;
+  /**
+   * GAFlightCriteria:expression:
+   *
+   * Opaque criteria expression, dependent on server implementation.
+   *
+   * Since: 5.0.0
+   */
+  spec = g_param_spec_boxed("expression",
+                            "Expression",
+                            "Opaque criteria expression, "
+                            "dependent on server implementation",
+                            G_TYPE_BYTES,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_EXPRESSION, spec);
+}
+
+/**
+ * gaflight_criteria_new:
+ * @expression: A #GBytes.
+ *
+ * Returns: The newly created #GAFlightCriteria, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GAFlightCriteria *
+gaflight_criteria_new(GBytes *expression)
+{
+  return GAFLIGHT_CRITERIA(
+    g_object_new(GAFLIGHT_TYPE_CRITERIA, "expression", expression, NULL));
+}
+
+typedef struct GAFlightLocationPrivate_
+{
+  arrow::flight::Location location;
+} GAFlightLocationPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightLocation, gaflight_location, G_TYPE_OBJECT)
+
+#define GAFLIGHT_LOCATION_GET_PRIVATE(obj)                                               \
+  static_cast<GAFlightLocationPrivate *>(                                                \
+    gaflight_location_get_instance_private(GAFLIGHT_LOCATION(obj)))
+
+static void
+gaflight_location_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_LOCATION_GET_PRIVATE(object);
+
+  priv->location.~Location();
+
+  G_OBJECT_CLASS(gaflight_location_parent_class)->finalize(object);
+}
+
+static void
+gaflight_location_init(GAFlightLocation *object)
+{
+  auto priv = GAFLIGHT_LOCATION_GET_PRIVATE(object);
+  new (&priv->location) arrow::flight::Location;
+}
+
+static void
+gaflight_location_class_init(GAFlightLocationClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_location_finalize;
+}
+
+/**
+ * gaflight_location_new:
+ * @uri: An URI to specify location.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable): The newly created location, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GAFlightLocation *
+gaflight_location_new(const gchar *uri, GError **error)
+{
+  auto location = GAFLIGHT_LOCATION(g_object_new(GAFLIGHT_TYPE_LOCATION, NULL));
+  auto flight_location = gaflight_location_get_raw(location);
+  if (garrow::check(error,
+                    arrow::flight::Location::Parse(uri).Value(flight_location),
+                    "[flight-location][new]")) {
+    return location;
+  } else {
+    g_object_unref(location);
+    return NULL;
+  }
+}
+
+/**
+ * gaflight_location_to_string:
+ * @location: A #GAFlightLocation.
+ *
+ * Returns: A representation of this URI as a string.
+ *
+ *   It should be freed with g_free() when no longer needed.
+ *
+ * Since: 5.0.0
+ */
+gchar *
+gaflight_location_to_string(GAFlightLocation *location)
+{
+  const auto flight_location = gaflight_location_get_raw(location);
+  const auto string = flight_location->ToString();
+  return g_strdup(string.c_str());
+}
+
+/**
+ * gaflight_location_get_scheme:
+ * @location: A #GAFlightLocation.
+ *
+ * Returns: The scheme of this URI.
+ *
+ *   It should be freed with g_free() when no longer needed.
+ *
+ * Since: 5.0.0
+ */
+gchar *
+gaflight_location_get_scheme(GAFlightLocation *location)
+{
+  const auto flight_location = gaflight_location_get_raw(location);
+  const auto scheme = flight_location->scheme();
+  return g_strdup(scheme.c_str());
+}
+
+/**
+ * gaflight_location_equal:
+ * @location: A #GAFlightLocation.
+ * @other_location: A #GAFlightLocation to be compared.
+ *
+ * Returns: %TRUE if both of them represents the same URI, %FALSE otherwise.
+ *
+ * Since: 5.0.0
+ */
+gboolean
+gaflight_location_equal(GAFlightLocation *location, GAFlightLocation *other_location)
+{
+  const auto flight_location = gaflight_location_get_raw(location);
+  const auto flight_other_location = gaflight_location_get_raw(other_location);
+  return flight_location->Equals(*flight_other_location);
+}
+
+typedef struct GAFlightDescriptorPrivate_
+{
+  arrow::flight::FlightDescriptor descriptor;
+} GAFlightDescriptorPrivate;
+
+enum {
+  PROP_DESCRIPTOR = 1,
+};
+
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(GAFlightDescriptor,
+                                    gaflight_descriptor,
+                                    G_TYPE_OBJECT)
+
+#define GAFLIGHT_DESCRIPTOR_GET_PRIVATE(obj)                                             \
+  static_cast<GAFlightDescriptorPrivate *>(                                              \
+    gaflight_descriptor_get_instance_private(GAFLIGHT_DESCRIPTOR(obj)))
+
+static void
+gaflight_descriptor_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_DESCRIPTOR_GET_PRIVATE(object);
+
+  priv->descriptor.~FlightDescriptor();
+
+  G_OBJECT_CLASS(gaflight_descriptor_parent_class)->finalize(object);
+}
+
+static void
+gaflight_descriptor_set_property(GObject *object,
+                                 guint prop_id,
+                                 const GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_DESCRIPTOR_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_DESCRIPTOR:
+    priv->descriptor =
+      *static_cast<arrow::flight::FlightDescriptor *>(g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_descriptor_init(GAFlightDescriptor *object)
+{
+  auto priv = GAFLIGHT_DESCRIPTOR_GET_PRIVATE(object);
+  new (&priv->descriptor) arrow::flight::FlightDescriptor;
+}
+
+static void
+gaflight_descriptor_class_init(GAFlightDescriptorClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_descriptor_finalize;
+  gobject_class->set_property = gaflight_descriptor_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "descriptor",
+    "Descriptor",
+    "The raw arrow::flight::FlightDescriptor",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_EXPRESSION, spec);
+}
+
+/**
+ * gaflight_descriptor_to_string:
+ * @descriptor: A #GAFlightDescriptor.
+ *
+ * Returns: A descriptor as a string.
+ *
+ *   It should be freed with g_free() when no longer needed.
+ *
+ * Since: 5.0.0
+ */
+gchar *
+gaflight_descriptor_to_string(GAFlightDescriptor *descriptor)
+{
+  const auto flight_descriptor = gaflight_descriptor_get_raw(descriptor);
+  const auto string = flight_descriptor->ToString();
+  return g_strdup(string.c_str());
+}
+
+/**
+ * gaflight_descriptor_equal:
+ * @descriptor: A #GAFlightDescriptor.
+ * @other_descriptor: A #GAFlightDescriptor to be compared.
+ *
+ * Returns: %TRUE if both of them represents the same descriptor,
+ *   %FALSE otherwise.
+ *
+ * Since: 5.0.0
+ */
+gboolean
+gaflight_descriptor_equal(GAFlightDescriptor *descriptor,
+                          GAFlightDescriptor *other_descriptor)
+{
+  const auto flight_descriptor = gaflight_descriptor_get_raw(descriptor);
+  const auto flight_other_descriptor = gaflight_descriptor_get_raw(other_descriptor);
+  return flight_descriptor->Equals(*flight_other_descriptor);
+}
+
+G_DEFINE_TYPE(GAFlightPathDescriptor, gaflight_path_descriptor, GAFLIGHT_TYPE_DESCRIPTOR)
+
+static void
+gaflight_path_descriptor_init(GAFlightPathDescriptor *object)
+{
+}
+
+static void
+gaflight_path_descriptor_class_init(GAFlightPathDescriptorClass *klass)
+{
+}
+
+/**
+ * gaflight_path_descriptor_new:
+ * @paths: (array length=n_paths): List of paths identifying a
+ *   particular dataset.
+ * @n_paths: The number of @paths.
+ *
+ * Returns: The newly created #GAFlightPathDescriptor.
+ *
+ * Since: 5.0.0
+ */
+GAFlightPathDescriptor *
+gaflight_path_descriptor_new(const gchar **paths, gsize n_paths)
+{
+  std::vector<std::string> flight_paths;
+  for (gsize i = 0; i < n_paths; i++) {
+    flight_paths.push_back(paths[i]);
+  }
+  auto flight_descriptor = arrow::flight::FlightDescriptor::Path(flight_paths);
+  return GAFLIGHT_PATH_DESCRIPTOR(gaflight_descriptor_new_raw(&flight_descriptor));
+}
+
+/**
+ * gaflight_path_descriptor_get_paths:
+ * @descriptor: A #GAFlightPathDescriptor.
+ *
+ * Returns: (nullable) (array zero-terminated=1) (transfer full):
+ *   The paths in this descriptor.
+ *
+ *   It must be freed with g_strfreev() when no longer needed.
+ *
+ * Since: 5.0.0
+ */
+gchar **
+gaflight_path_descriptor_get_paths(GAFlightPathDescriptor *descriptor)
+{
+  const auto flight_descriptor =
+    gaflight_descriptor_get_raw(GAFLIGHT_DESCRIPTOR(descriptor));
+  const auto &flight_paths = flight_descriptor->path;
+  if (flight_paths.empty()) {
+    return NULL;
+  } else {
+    auto paths = g_new(gchar *, flight_paths.size() + 1);
+    gsize i = 0;
+    for (const auto &flight_path : flight_paths) {
+      paths[i++] = g_strdup(flight_path.c_str());
+    }
+    paths[i] = NULL;
+    return paths;
+  }
+}
+
+G_DEFINE_TYPE(GAFlightCommandDescriptor,
+              gaflight_command_descriptor,
+              GAFLIGHT_TYPE_DESCRIPTOR)
+
+static void
+gaflight_command_descriptor_init(GAFlightCommandDescriptor *object)
+{
+}
+
+static void
+gaflight_command_descriptor_class_init(GAFlightCommandDescriptorClass *klass)
+{
+}
+
+/**
+ * gaflight_command_descriptor_new:
+ * @command: Opaque value used to express a command.
+ *
+ * Returns: The newly created #GAFlightCommandDescriptor.
+ *
+ * Since: 5.0.0
+ */
+GAFlightCommandDescriptor *
+gaflight_command_descriptor_new(const gchar *command)
+{
+  auto flight_descriptor = arrow::flight::FlightDescriptor::Command(command);
+  return GAFLIGHT_COMMAND_DESCRIPTOR(gaflight_descriptor_new_raw(&flight_descriptor));
+}
+
+/**
+ * gaflight_command_descriptor_get_command:
+ * @descriptor: A #GAFlightCommandDescriptor.
+ *
+ * Returns: The opaque value used to express a command.
+ *
+ *   It should be freed with g_free() when no longer needed.
+ *
+ * Since: 5.0.0
+ */
+gchar *
+gaflight_command_descriptor_get_command(GAFlightCommandDescriptor *descriptor)
+{
+  const auto flight_descriptor =
+    gaflight_descriptor_get_raw(GAFLIGHT_DESCRIPTOR(descriptor));
+  const auto &flight_command = flight_descriptor->cmd;
+  return g_strdup(flight_command.c_str());
+}
+
+typedef struct GAFlightTicketPrivate_
+{
+  arrow::flight::Ticket ticket;
+  GBytes *data;
+} GAFlightTicketPrivate;
+
+enum {
+  PROP_DATA = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightTicket, gaflight_ticket, G_TYPE_OBJECT)
+
+#define GAFLIGHT_TICKET_GET_PRIVATE(obj)                                                 \
+  static_cast<GAFlightTicketPrivate *>(                                                  \
+    gaflight_ticket_get_instance_private(GAFLIGHT_TICKET(obj)))
+
+static void
+gaflight_ticket_dispose(GObject *object)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(object);
+
+  if (priv->data) {
+    g_bytes_unref(priv->data);
+    priv->data = NULL;
+  }
+
+  G_OBJECT_CLASS(gaflight_ticket_parent_class)->dispose(object);
+}
+
+static void
+gaflight_ticket_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(object);
+
+  priv->ticket.~Ticket();
+
+  G_OBJECT_CLASS(gaflight_ticket_parent_class)->finalize(object);
+}
+
+static void
+gaflight_ticket_set_property(GObject *object,
+                             guint prop_id,
+                             const GValue *value,
+                             GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_DATA:
+    if (priv->data) {
+      g_bytes_unref(priv->data);
+    }
+    priv->data = static_cast<GBytes *>(g_value_dup_boxed(value));
+    {
+      gsize size;
+      auto data = g_bytes_get_data(priv->data, &size);
+      priv->ticket.ticket.assign(static_cast<const char *>(data), size);
+    }
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_ticket_get_property(GObject *object,
+                             guint prop_id,
+                             GValue *value,
+                             GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_DATA:
+    g_value_set_boxed(value, priv->data);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_ticket_init(GAFlightTicket *object)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(object);
+  new (&priv->ticket) arrow::flight::Ticket;
+}
+
+static void
+gaflight_ticket_class_init(GAFlightTicketClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = gaflight_ticket_dispose;
+  gobject_class->finalize = gaflight_ticket_finalize;
+  gobject_class->set_property = gaflight_ticket_set_property;
+  gobject_class->get_property = gaflight_ticket_get_property;
+
+  GParamSpec *spec;
+  /**
+   * GAFlightTicket:data:
+   *
+   * Opaque identifier or credential to use when requesting a data
+   * stream with the DoGet RPC.
+   *
+   * Since: 5.0.0
+   */
+  spec = g_param_spec_boxed("data",
+                            "Data",
+                            "Opaque identifier or credential to use "
+                            "when requesting a data stream with the DoGet RPC",
+                            G_TYPE_BYTES,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_DATA, spec);
+}
+
+/**
+ * gaflight_ticket_new:
+ * @data: A #GBytes.
+ *
+ * Returns: The newly created #GAFlightTicket, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GAFlightTicket *
+gaflight_ticket_new(GBytes *data)
+{
+  return GAFLIGHT_TICKET(g_object_new(GAFLIGHT_TYPE_TICKET, "data", data, NULL));
+}
+
+/**
+ * gaflight_ticket_equal:
+ * @ticket: A #GAFlightTicket.
+ * @other_ticket: A #GAFlightTicket to be compared.
+ *
+ * Returns: %TRUE if both of them represents the same ticket, %FALSE otherwise.
+ *
+ * Since: 5.0.0
+ */
+gboolean
+gaflight_ticket_equal(GAFlightTicket *ticket, GAFlightTicket *other_ticket)
+{
+  const auto flight_ticket = gaflight_ticket_get_raw(ticket);
+  const auto flight_other_ticket = gaflight_ticket_get_raw(other_ticket);
+  return flight_ticket->Equals(*flight_other_ticket);
+}
+
+typedef struct GAFlightEndpointPrivate_
+{
+  arrow::flight::FlightEndpoint endpoint;
+  GAFlightTicket *ticket;
+  GList *locations;
+} GAFlightEndpointPrivate;
+
+enum {
+  PROP_TICKET = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightEndpoint, gaflight_endpoint, G_TYPE_OBJECT)
+
+#define GAFLIGHT_ENDPOINT_GET_PRIVATE(obj)                                               \
+  static_cast<GAFlightEndpointPrivate *>(                                                \
+    gaflight_endpoint_get_instance_private(GAFLIGHT_ENDPOINT(obj)))
+
+static void
+gaflight_endpoint_dispose(GObject *object)
+{
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(object);
+
+  if (priv->ticket) {
+    g_object_unref(priv->ticket);
+    priv->ticket = NULL;
+  }
+
+  if (priv->locations) {
+    g_list_free_full(priv->locations, g_object_unref);
+    priv->locations = NULL;
+  }
+
+  G_OBJECT_CLASS(gaflight_endpoint_parent_class)->dispose(object);
+}
+
+static void
+gaflight_endpoint_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(object);
+
+  priv->endpoint.~FlightEndpoint();
+
+  G_OBJECT_CLASS(gaflight_endpoint_parent_class)->finalize(object);
+}
+
+static void
+gaflight_endpoint_get_property(GObject *object,
+                               guint prop_id,
+                               GValue *value,
+                               GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_TICKET:
+    g_value_set_object(value, priv->ticket);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_endpoint_init(GAFlightEndpoint *object)
+{
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(object);
+  new (&priv->endpoint) arrow::flight::FlightEndpoint;
+}
+
+static void
+gaflight_endpoint_class_init(GAFlightEndpointClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = gaflight_endpoint_dispose;
+  gobject_class->finalize = gaflight_endpoint_finalize;
+  gobject_class->get_property = gaflight_endpoint_get_property;
+
+  GParamSpec *spec;
+  /**
+   * GAFlightEndpoint:ticket:
+   *
+   * Opaque ticket identify; use with DoGet RPC.
+   *
+   * Since: 5.0.0
+   */
+  spec = g_param_spec_object("ticket",
+                             "Ticket",
+                             "Opaque ticket identify; use with DoGet RPC",
+                             GAFLIGHT_TYPE_TICKET,
+                             static_cast<GParamFlags>(G_PARAM_READABLE));
+  g_object_class_install_property(gobject_class, PROP_TICKET, spec);
+}
+
+/**
+ * gaflight_endpoint_new:
+ * @ticket: A #GAFlightTicket.
+ * @locations: (element-type GAFlightLocation): A list of #GAFlightLocation.
+ *
+ * Returns: The newly created #GAFlightEndpoint, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GAFlightEndpoint *
+gaflight_endpoint_new(GAFlightTicket *ticket, GList *locations)
+{
+  auto endpoint = gaflight_endpoint_new_raw(nullptr, ticket);
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(endpoint);
+  for (auto node = locations; node; node = node->next) {
+    auto location = GAFLIGHT_LOCATION(node->data);
+    priv->endpoint.locations.push_back(*gaflight_location_get_raw(location));
+  }
+  return endpoint;
+}
+
+/**
+ * gaflight_endpoint_equal:
+ * @endpoint: A #GAFlightEndpoint.
+ * @other_endpoint: A #GAFlightEndpoint to be compared.
+ *
+ * Returns: %TRUE if both of them represents the same endpoint,
+ *   %FALSE otherwise.
+ *
+ * Since: 5.0.0
+ */
+gboolean
+gaflight_endpoint_equal(GAFlightEndpoint *endpoint, GAFlightEndpoint *other_endpoint)
+{
+  const auto flight_endpoint = gaflight_endpoint_get_raw(endpoint);
+  const auto flight_other_endpoint = gaflight_endpoint_get_raw(other_endpoint);
+  return flight_endpoint->Equals(*flight_other_endpoint);
+}
+
+/**
+ * gaflight_endpoint_get_locations:
+ * @endpoint: A #GAFlightEndpoint.
+ *
+ * Returns: (nullable) (element-type GAFlightLocation) (transfer full):
+ *   The locations in this endpoint.
+ *
+ *   It must be freed with g_list_free() and g_object_unref() when no
+ *   longer needed. You can use `g_list_free_full(locations,
+ *   g_object_unref)`.
+ *
+ * Since: 5.0.0
+ */
+GList *
+gaflight_endpoint_get_locations(GAFlightEndpoint *endpoint)
+{
+  const auto flight_endpoint = gaflight_endpoint_get_raw(endpoint);
+  GList *locations = NULL;
+  for (const auto &flight_location : flight_endpoint->locations) {
+    auto location = gaflight_location_new(flight_location.ToString().c_str(), nullptr);
+    locations = g_list_prepend(locations, location);
+  }
+  return g_list_reverse(locations);
+}
+
+typedef struct GAFlightInfoPrivate_
+{
+  arrow::flight::FlightInfo info;
+} GAFlightInfoPrivate;
+
+enum {
+  PROP_INFO = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightInfo, gaflight_info, G_TYPE_OBJECT)
+
+#define GAFLIGHT_INFO_GET_PRIVATE(obj)                                                   \
+  static_cast<GAFlightInfoPrivate *>(                                                    \
+    gaflight_info_get_instance_private(GAFLIGHT_INFO(obj)))
+
+static void
+gaflight_info_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_INFO_GET_PRIVATE(object);
+
+  priv->info.~FlightInfo();
+
+  G_OBJECT_CLASS(gaflight_info_parent_class)->finalize(object);
+}
+
+static void
+gaflight_info_set_property(GObject *object,
+                           guint prop_id,
+                           const GValue *value,
+                           GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_INFO_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_INFO:
+    {
+      auto info = static_cast<arrow::flight::FlightInfo *>(g_value_get_pointer(value));
+      new (&(priv->info)) arrow::flight::FlightInfo(*info);
+    }
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_info_init(GAFlightInfo *object)
+{
+}
+
+static void
+gaflight_info_class_init(GAFlightInfoClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_info_finalize;
+  gobject_class->set_property = gaflight_info_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "info",
+    "Info",
+    "The raw arrow::flight::FlightInfo *",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_INFO, spec);
+}
+
+/**
+ * gaflight_info_new:
+ * @schema: A #GArrowSchema.
+ * @descriptor: A #GAFlightDescriptor.
+ * @endpoints: (element-type GAFlightEndpoint): A list of #GAFlightEndpoint.
+ * @total_records: The number of total records.
+ * @total_bytes: The number of total bytes.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable): The newly created #GAFlightInfo, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GAFlightInfo *
+gaflight_info_new(GArrowSchema *schema,
+                  GAFlightDescriptor *descriptor,
+                  GList *endpoints,
+                  gint64 total_records,
+                  gint64 total_bytes,
+                  GError **error)
+{
+  auto arrow_schema = garrow_schema_get_raw(schema);
+  auto flight_descriptor = gaflight_descriptor_get_raw(descriptor);
+  std::vector<arrow::flight::FlightEndpoint> flight_endpoints;
+  for (auto node = endpoints; node; node = node->next) {
+    auto endpoint = GAFLIGHT_ENDPOINT(node->data);
+    flight_endpoints.push_back(*gaflight_endpoint_get_raw(endpoint));
+  }
+  auto flight_info_result = arrow::flight::FlightInfo::Make(*arrow_schema,
+                                                            *flight_descriptor,
+                                                            flight_endpoints,
+                                                            total_records,
+                                                            total_bytes);
+  if (!garrow::check(error, flight_info_result, "[flight-info][new]")) {
+    return NULL;
+  }
+  return gaflight_info_new_raw(&(*flight_info_result));
+}
+
+/**
+ * gaflight_info_equal:
+ * @info: A #GAFlightInfo.
+ * @other_info: A #GAFlightInfo to be compared.
+ *
+ * Returns: %TRUE if both of them represents the same information,
+ *   %FALSE otherwise.
+ *
+ * Since: 5.0.0
+ */
+gboolean
+gaflight_info_equal(GAFlightInfo *info, GAFlightInfo *other_info)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  const auto flight_other_info = gaflight_info_get_raw(other_info);
+  return (flight_info->serialized_schema() == flight_other_info->serialized_schema()) &&
+         (flight_info->descriptor() == flight_other_info->descriptor()) &&
+         (flight_info->endpoints() == flight_other_info->endpoints()) &&
+         (flight_info->total_records() == flight_other_info->total_records()) &&
+         (flight_info->total_bytes() == flight_other_info->total_bytes());
+}
+
+/**
+ * gaflight_info_get_schema:
+ * @info: A #GAFlightInfo.
+ * @options: (nullable): A #GArrowReadOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): Deserialized #GArrowSchema, %NULL on error.
+ *
+ * Since: 5.0.0
+ */
+GArrowSchema *
+gaflight_info_get_schema(GAFlightInfo *info, GArrowReadOptions *options, GError **error)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  arrow::Status status;
+  std::shared_ptr<arrow::Schema> arrow_schema;
+  if (options) {
+    auto arrow_memo = garrow_read_options_get_dictionary_memo_raw(options);
+    status = flight_info->GetSchema(arrow_memo).Value(&arrow_schema);
+  } else {
+    arrow::ipc::DictionaryMemo arrow_memo;
+    status = flight_info->GetSchema(&arrow_memo).Value(&arrow_schema);
+  }
+  if (garrow::check(error, status, "[flight-info][get-schema]")) {
+    return garrow_schema_new_raw(&arrow_schema);
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * gaflight_info_get_descriptor:
+ * @info: A #GAFlightInfo.
+ *
+ * Returns: (transfer full): The #GAFlightDescriptor of the information.
+ *
+ * Since: 5.0.0
+ */
+GAFlightDescriptor *
+gaflight_info_get_descriptor(GAFlightInfo *info)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  return gaflight_descriptor_new_raw(&(flight_info->descriptor()));
+}
+
+/**
+ * gaflight_info_get_endpoints:
+ * @info: A #GAFlightInfo.
+ *
+ * Returns: (element-type GAFlightEndpoint) (transfer full):
+ *   The list of #GAFlightEndpoint of the information.
+ *
+ * Since: 5.0.0
+ */
+GList *
+gaflight_info_get_endpoints(GAFlightInfo *info)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  GList *endpoints = NULL;
+  for (const auto &flight_endpoint : flight_info->endpoints()) {
+    auto endpoint = gaflight_endpoint_new_raw(&flight_endpoint, nullptr);
+    endpoints = g_list_prepend(endpoints, endpoint);
+  }
+  return g_list_reverse(endpoints);
+}
+
+/**
+ * gaflight_info_get_total_records:
+ * @info: A #GAFlightInfo.
+ *
+ * Returns: The number of total records of the information.
+ *
+ * Since: 5.0.0
+ */
+gint64
+gaflight_info_get_total_records(GAFlightInfo *info)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  return flight_info->total_records();
+}
+
+/**
+ * gaflight_info_get_total_bytes:
+ * @info: A #GAFlightInfo.
+ *
+ * Returns: The number of total bytes of the information.
+ *
+ * Since: 5.0.0
+ */
+gint64
+gaflight_info_get_total_bytes(GAFlightInfo *info)
+{
+  const auto flight_info = gaflight_info_get_raw(info);
+  return flight_info->total_bytes();
+}
+
+typedef struct GAFlightStreamChunkPrivate_
+{
+  arrow::flight::FlightStreamChunk chunk;
+} GAFlightStreamChunkPrivate;
+
+enum {
+  PROP_CHUNK = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GAFlightStreamChunk, gaflight_stream_chunk, G_TYPE_OBJECT)
+
+#define GAFLIGHT_STREAM_CHUNK_GET_PRIVATE(obj)                                           \
+  static_cast<GAFlightStreamChunkPrivate *>(                                             \
+    gaflight_stream_chunk_get_instance_private(GAFLIGHT_STREAM_CHUNK(obj)))
+
+static void
+gaflight_stream_chunk_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_STREAM_CHUNK_GET_PRIVATE(object);
+
+  priv->chunk.~FlightStreamChunk();
+
+  G_OBJECT_CLASS(gaflight_info_parent_class)->finalize(object);
+}
+
+static void
+gaflight_stream_chunk_set_property(GObject *object,
+                                   guint prop_id,
+                                   const GValue *value,
+                                   GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_STREAM_CHUNK_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_CHUNK:
+    priv->chunk =
+      *static_cast<arrow::flight::FlightStreamChunk *>(g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_stream_chunk_init(GAFlightStreamChunk *object)
+{
+}
+
+static void
+gaflight_stream_chunk_class_init(GAFlightStreamChunkClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_stream_chunk_finalize;
+  gobject_class->set_property = gaflight_stream_chunk_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "chunk",
+    "Stream chunk",
+    "The raw arrow::flight::FlightStreamChunk *",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_CHUNK, spec);
+}
+
+/**
+ * gaflight_stream_chunk_get_data:
+ * @chunk: A #GAFlightStreamChunk.
+ *
+ * Returns: (transfer full): The data of the chunk.
+ *
+ * Since: 6.0.0
+ */
+GArrowRecordBatch *
+gaflight_stream_chunk_get_data(GAFlightStreamChunk *chunk)
+{
+  auto flight_chunk = gaflight_stream_chunk_get_raw(chunk);
+  return garrow_record_batch_new_raw(&(flight_chunk->data));
+}
+
+/**
+ * gaflight_stream_chunk_get_metadata:
+ * @chunk: A #GAFlightStreamChunk.
+ *
+ * Returns: (nullable) (transfer full): The metadata of the chunk.
+ *
+ *   The metadata may be NULL.
+ *
+ * Since: 6.0.0
+ */
+GArrowBuffer *
+gaflight_stream_chunk_get_metadata(GAFlightStreamChunk *chunk)
+{
+  auto flight_chunk = gaflight_stream_chunk_get_raw(chunk);
+  if (flight_chunk->app_metadata) {
+    return garrow_buffer_new_raw(&(flight_chunk->app_metadata));
+  } else {
+    return NULL;
+  }
+}
+
+typedef struct GAFlightRecordBatchReaderPrivate_
+{
+  arrow::flight::MetadataRecordBatchReader *reader;
+  bool is_owner;
+} GAFlightRecordBatchReaderPrivate;
+
+enum {
+  PROP_RECORD_BATCH_READER_READER = 1,
+  PROP_RECORD_BATCH_READER_IS_OWNER,
+};
+
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(GAFlightRecordBatchReader,
+                                    gaflight_record_batch_reader,
+                                    G_TYPE_OBJECT)
+
+#define GAFLIGHT_RECORD_BATCH_READER_GET_PRIVATE(obj)                                    \
+  static_cast<GAFlightRecordBatchReaderPrivate *>(                                       \
+    gaflight_record_batch_reader_get_instance_private(                                   \
+      GAFLIGHT_RECORD_BATCH_READER(obj)))
+
+static void
+gaflight_record_batch_reader_finalize(GObject *object)
+{
+  auto priv = GAFLIGHT_RECORD_BATCH_READER_GET_PRIVATE(object);
+  if (priv->is_owner) {
+    delete priv->reader;
+  }
+  G_OBJECT_CLASS(gaflight_record_batch_reader_parent_class)->finalize(object);
+}
+
+static void
+gaflight_record_batch_reader_set_property(GObject *object,
+                                          guint prop_id,
+                                          const GValue *value,
+                                          GParamSpec *pspec)
+{
+  auto priv = GAFLIGHT_RECORD_BATCH_READER_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_RECORD_BATCH_READER_READER:
+    priv->reader =
+      static_cast<arrow::flight::MetadataRecordBatchReader *>(g_value_get_pointer(value));
+    break;
+  case PROP_RECORD_BATCH_READER_IS_OWNER:
+    priv->is_owner = g_value_get_boolean(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gaflight_record_batch_reader_init(GAFlightRecordBatchReader *object)
+{
+}
+
+static void
+gaflight_record_batch_reader_class_init(GAFlightRecordBatchReaderClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gaflight_record_batch_reader_finalize;
+  gobject_class->set_property = gaflight_record_batch_reader_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "reader",
+    nullptr,
+    nullptr,
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_RECORD_BATCH_READER_READER, spec);
+
+  spec = g_param_spec_boolean(
+    "is-owner",
+    nullptr,
+    nullptr,
+    TRUE,
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_RECORD_BATCH_READER_IS_OWNER, spec);
+}
+
+/**
+ * gaflight_record_batch_reader_read_next:
+ * @reader: A #GAFlightRecordBatchReader.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): The next chunk on success, %NULL on end
+ *   of stream, %NULL on error.
+ *
+ * Since: 6.0.0
+ */
+GAFlightStreamChunk *
+gaflight_record_batch_reader_read_next(GAFlightRecordBatchReader *reader, GError **error)
+{
+  auto flight_reader = gaflight_record_batch_reader_get_raw(reader);
+  arrow::flight::FlightStreamChunk flight_chunk;
+  auto status = flight_reader->Next().Value(&flight_chunk);
+  if (garrow::check(error, status, "[flight-record-batch-reader][read-next]")) {
+    if (flight_chunk.data) {
+      return gaflight_stream_chunk_new_raw(&flight_chunk);
+    } else {
+      return NULL;
+    }
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * gaflight_record_batch_reader_read_all:
+ * @reader: A #GAFlightRecordBatchReader.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): The all data on success, %NULL on error.
+ *
+ * Since: 6.0.0
+ */
+GArrowTable *
+gaflight_record_batch_reader_read_all(GAFlightRecordBatchReader *reader, GError **error)
+{
+  auto flight_reader = gaflight_record_batch_reader_get_raw(reader);
+  std::shared_ptr<arrow::Table> arrow_table;
+  auto status = flight_reader->ToTable().Value(&arrow_table);
+  if (garrow::check(error, status, "[flight-record-batch-reader][read-all]")) {
+    return garrow_table_new_raw(&arrow_table);
+  } else {
+    return NULL;
+  }
+}
+
+G_DEFINE_ABSTRACT_TYPE(GAFlightRecordBatchWriter,
+                       gaflight_record_batch_writer,
+                       GARROW_TYPE_RECORD_BATCH_WRITER)
+
+static void
+gaflight_record_batch_writer_init(GAFlightRecordBatchWriter *object)
+{
+}
+
+static void
+gaflight_record_batch_writer_class_init(GAFlightRecordBatchWriterClass *klass)
+{
+}
+
+/**
+ * gaflight_record_batch_writer_begin:
+ * @writer: A #GAFlightRecordBatchWriter.
+ * @schema: A #GArrowSchema.
+ * @options: (nullable): A #GArrowWriteOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Begins writing data with the given schema. Only used with
+ * `DoExchange`.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 18.0.0
+ */
+gboolean
+gaflight_record_batch_writer_begin(GAFlightRecordBatchWriter *writer,
+                                   GArrowSchema *schema,
+                                   GArrowWriteOptions *options,
+                                   GError **error)
+{
+  auto flight_writer = std::static_pointer_cast<arrow::flight::MetadataRecordBatchWriter>(
+    garrow_record_batch_writer_get_raw(GARROW_RECORD_BATCH_WRITER(writer)));
+  auto arrow_schema = garrow_schema_get_raw(schema);
+  arrow::ipc::IpcWriteOptions arrow_write_options;
+  if (options) {
+    arrow_write_options = *garrow_write_options_get_raw(options);
+  } else {
+    arrow_write_options = arrow::ipc::IpcWriteOptions::Defaults();
+  }
+  return garrow::check(error,
+                       flight_writer->Begin(arrow_schema, arrow_write_options),
+                       "[flight-record-batch-writer][begin]");
+}
+
+/**
+ * gaflight_record_batch_writer_write_metadata:
+ * @writer: A #GAFlightRecordBatchWriter.
+ * @metadata: A #GArrowBuffer.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Write metadata.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 18.0.0
+ */
+gboolean
+gaflight_record_batch_writer_write_metadata(GAFlightRecordBatchWriter *writer,
+                                            GArrowBuffer *metadata,
+                                            GError **error)
+{
+  auto flight_writer = std::static_pointer_cast<arrow::flight::MetadataRecordBatchWriter>(
+    garrow_record_batch_writer_get_raw(GARROW_RECORD_BATCH_WRITER(writer)));
+  auto arrow_metadata = garrow_buffer_get_raw(metadata);
+  return garrow::check(error,
+                       flight_writer->WriteMetadata(arrow_metadata),
+                       "[flight-record-batch-writer][write-metadata]");
+}
+
+/**
+ * gaflight_record_batch_writer_write_record_batch:
+ * @writer: A #GAFlightRecordBatchWriter.
+ * @record_batch: A #GArrowRecordBatch.
+ * @metadata: (nullable): A #GArrowBuffer.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Write a record batch with metadata.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 18.0.0
+ */
+gboolean
+gaflight_record_batch_writer_write_record_batch(GAFlightRecordBatchWriter *writer,
+                                                GArrowRecordBatch *record_batch,
+                                                GArrowBuffer *metadata,
+                                                GError **error)
+{
+  auto flight_writer = std::static_pointer_cast<arrow::flight::MetadataRecordBatchWriter>(
+    garrow_record_batch_writer_get_raw(GARROW_RECORD_BATCH_WRITER(writer)));
+  auto arrow_record_batch = garrow_record_batch_get_raw(record_batch);
+  auto arrow_metadata = garrow_buffer_get_raw(metadata);
+  return garrow::check(
+    error,
+    flight_writer->WriteWithMetadata(*arrow_record_batch, arrow_metadata),
+    "[flight-record-batch-writer][write]");
+}
+
+G_END_DECLS
+
+GAFlightCriteria *
+gaflight_criteria_new_raw(const arrow::flight::Criteria *flight_criteria)
+{
+  auto criteria = g_object_new(GAFLIGHT_TYPE_CRITERIA, NULL);
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(criteria);
+  priv->criteria = *flight_criteria;
+  priv->expression =
+    g_bytes_new(priv->criteria.expression.data(), priv->criteria.expression.size());
+  return GAFLIGHT_CRITERIA(criteria);
+}
+
+arrow::flight::Criteria *
+gaflight_criteria_get_raw(GAFlightCriteria *criteria)
+{
+  auto priv = GAFLIGHT_CRITERIA_GET_PRIVATE(criteria);
+  return &(priv->criteria);
+}
+
+arrow::flight::Location *
+gaflight_location_get_raw(GAFlightLocation *location)
+{
+  auto priv = GAFLIGHT_LOCATION_GET_PRIVATE(location);
+  return &(priv->location);
+}
+
+GAFlightDescriptor *
+gaflight_descriptor_new_raw(const arrow::flight::FlightDescriptor *flight_descriptor)
+{
+  GType gtype = GAFLIGHT_TYPE_DESCRIPTOR;
+  switch (flight_descriptor->type) {
+  case arrow::flight::FlightDescriptor::DescriptorType::PATH:
+    gtype = GAFLIGHT_TYPE_PATH_DESCRIPTOR;
+    break;
+  case arrow::flight::FlightDescriptor::DescriptorType::CMD:
+    gtype = GAFLIGHT_TYPE_COMMAND_DESCRIPTOR;
+    break;
+  default:
+    break;
+  }
+  return GAFLIGHT_DESCRIPTOR(g_object_new(gtype, "descriptor", flight_descriptor, NULL));
+}
+
+arrow::flight::FlightDescriptor *
+gaflight_descriptor_get_raw(GAFlightDescriptor *descriptor)
+{
+  auto priv = GAFLIGHT_DESCRIPTOR_GET_PRIVATE(descriptor);
+  return &(priv->descriptor);
+}
+
+GAFlightTicket *
+gaflight_ticket_new_raw(const arrow::flight::Ticket *flight_ticket)
+{
+  auto ticket = g_object_new(GAFLIGHT_TYPE_TICKET, NULL);
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(ticket);
+  priv->ticket = *flight_ticket;
+  priv->data = g_bytes_new(priv->ticket.ticket.data(), priv->ticket.ticket.size());
+  return GAFLIGHT_TICKET(ticket);
+}
+
+arrow::flight::Ticket *
+gaflight_ticket_get_raw(GAFlightTicket *ticket)
+{
+  auto priv = GAFLIGHT_TICKET_GET_PRIVATE(ticket);
+  return &(priv->ticket);
+}
+
+GAFlightEndpoint *
+gaflight_endpoint_new_raw(const arrow::flight::FlightEndpoint *flight_endpoint,
+                          GAFlightTicket *ticket)
+{
+  auto endpoint = GAFLIGHT_ENDPOINT(g_object_new(GAFLIGHT_TYPE_ENDPOINT, NULL));
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(endpoint);
+  if (ticket) {
+    priv->ticket = ticket;
+    g_object_ref(priv->ticket);
+    priv->endpoint.ticket = *gaflight_ticket_get_raw(priv->ticket);
+  } else {
+    auto data = g_bytes_new(flight_endpoint->ticket.ticket.data(),
+                            flight_endpoint->ticket.ticket.length());
+    auto ticket = gaflight_ticket_new(data);
+    g_bytes_unref(data);
+    priv->ticket = ticket;
+    priv->endpoint.ticket.ticket = flight_endpoint->ticket.ticket;
+  }
+  if (flight_endpoint) {
+    priv->endpoint.locations = flight_endpoint->locations;
+  }
+  return endpoint;
+}
+
+arrow::flight::FlightEndpoint *
+gaflight_endpoint_get_raw(GAFlightEndpoint *endpoint)
+{
+  auto priv = GAFLIGHT_ENDPOINT_GET_PRIVATE(endpoint);
+  return &(priv->endpoint);
+}
+
+GAFlightInfo *
+gaflight_info_new_raw(arrow::flight::FlightInfo *flight_info)
+{
+  return GAFLIGHT_INFO(g_object_new(GAFLIGHT_TYPE_INFO, "info", flight_info, NULL));
+}
+
+arrow::flight::FlightInfo *
+gaflight_info_get_raw(GAFlightInfo *info)
+{
+  auto priv = GAFLIGHT_INFO_GET_PRIVATE(info);
+  return &(priv->info);
+}
+
+GAFlightStreamChunk *
+gaflight_stream_chunk_new_raw(arrow::flight::FlightStreamChunk *flight_chunk)
+{
+  return GAFLIGHT_STREAM_CHUNK(
+    g_object_new(GAFLIGHT_TYPE_STREAM_CHUNK, "chunk", flight_chunk, NULL));
+}
+
+arrow::flight::FlightStreamChunk *
+gaflight_stream_chunk_get_raw(GAFlightStreamChunk *chunk)
+{
+  auto priv = GAFLIGHT_STREAM_CHUNK_GET_PRIVATE(chunk);
+  return &(priv->chunk);
+}
+
+arrow::flight::MetadataRecordBatchReader *
+gaflight_record_batch_reader_get_raw(GAFlightRecordBatchReader *reader)
+{
+  auto priv = GAFLIGHT_RECORD_BATCH_READER_GET_PRIVATE(reader);
+  return priv->reader;
+}

--- a/cpp/cuda.cpp
+++ b/cpp/cuda.cpp
@@ -1,0 +1,915 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <arrow-glib/buffer.hpp>
+#include <arrow-glib/error.hpp>
+#include <arrow-glib/input-stream.hpp>
+#include <arrow-glib/ipc-options.hpp>
+#include <arrow-glib/output-stream.hpp>
+#include <arrow-glib/readable.hpp>
+#include <arrow-glib/record-batch.hpp>
+#include <arrow-glib/schema.hpp>
+
+#include <arrow-cuda-glib/cuda.hpp>
+
+G_BEGIN_DECLS
+
+/**
+ * SECTION: cuda
+ * @section_id: cuda-classes
+ * @title: CUDA related classes
+ * @include: arrow-cuda-glib/arrow-cuda-glib.h
+ *
+ * The following classes provide CUDA support for Apache Arrow data.
+ *
+ * #GArrowCUDADeviceManager is the starting point. You need at
+ * least one #GArrowCUDAContext to process Apache Arrow data on
+ * NVIDIA GPU.
+ *
+ * #GArrowCUDAContext is a class to keep context for one GPU. You
+ * need to create #GArrowCUDAContext for each GPU that you want to
+ * use. You can create #GArrowCUDAContext by
+ * garrow_cuda_device_manager_get_context().
+ *
+ * #GArrowCUDABuffer is a class for data on GPU. You can copy data
+ * on GPU to/from CPU by garrow_cuda_buffer_copy_to_host() and
+ * garrow_cuda_buffer_copy_from_host(). You can share data on GPU
+ * with other processes by garrow_cuda_buffer_export() and
+ * garrow_cuda_buffer_new_ipc().
+ *
+ * #GArrowCUDAHostBuffer is a class for data on CPU that is
+ * directly accessible from GPU.
+ *
+ * #GArrowCUDAIPCMemoryHandle is a class to share data on GPU with
+ * other processes. You can export your data on GPU to other processes
+ * by garrow_cuda_buffer_export() and
+ * garrow_cuda_ipc_memory_handle_new(). You can import other
+ * process data on GPU by garrow_cuda_ipc_memory_handle_new() and
+ * garrow_cuda_buffer_new_ipc().
+ *
+ * #GArrowCUDABufferInputStream is a class to read data in
+ * #GArrowCUDABuffer.
+ *
+ * #GArrowCUDABufferOutputStream is a class to write data into
+ * #GArrowCUDABuffer.
+ */
+
+G_DEFINE_TYPE(GArrowCUDADeviceManager, garrow_cuda_device_manager, G_TYPE_OBJECT)
+
+static void
+garrow_cuda_device_manager_init(GArrowCUDADeviceManager *object)
+{
+}
+
+static void
+garrow_cuda_device_manager_class_init(GArrowCUDADeviceManagerClass *klass)
+{
+}
+
+/**
+ * garrow_cuda_device_manager_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: A newly created #GArrowCUDADeviceManager on success,
+ *   %NULL on error.
+ *
+ * Since: 0.8.0
+ */
+GArrowCUDADeviceManager *
+garrow_cuda_device_manager_new(GError **error)
+{
+  auto arrow_manager = arrow::cuda::CudaDeviceManager::Instance();
+  if (garrow::check(error, arrow_manager, "[cuda][device-manager][new]")) {
+    auto manager = g_object_new(GARROW_CUDA_TYPE_DEVICE_MANAGER, NULL);
+    return GARROW_CUDA_DEVICE_MANAGER(manager);
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * garrow_cuda_device_manager_get_context:
+ * @manager: A #GArrowCUDADeviceManager.
+ * @gpu_number: A GPU device number for the target context.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): A newly created #GArrowCUDAContext on
+ *   success, %NULL on error. Contexts for the same GPU device number
+ *   share the same data internally.
+ *
+ * Since: 0.8.0
+ */
+GArrowCUDAContext *
+garrow_cuda_device_manager_get_context(GArrowCUDADeviceManager *manager,
+                                       gint gpu_number,
+                                       GError **error)
+{
+  auto arrow_manager = arrow::cuda::CudaDeviceManager::Instance();
+  auto arrow_cuda_context = (*arrow_manager)->GetContext(gpu_number);
+  if (garrow::check(error, arrow_cuda_context, "[cuda][device-manager][get-context]]")) {
+    return garrow_cuda_context_new_raw(&(*arrow_cuda_context));
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * garrow_cuda_device_manager_get_n_devices:
+ * @manager: A #GArrowCUDADeviceManager.
+ *
+ * Returns: The number of GPU devices.
+ *
+ * Since: 0.8.0
+ */
+gsize
+garrow_cuda_device_manager_get_n_devices(GArrowCUDADeviceManager *manager)
+{
+  auto arrow_manager = arrow::cuda::CudaDeviceManager::Instance();
+  return (*arrow_manager)->num_devices();
+}
+
+typedef struct GArrowCUDAContextPrivate_
+{
+  std::shared_ptr<arrow::cuda::CudaContext> context;
+} GArrowCUDAContextPrivate;
+
+enum {
+  PROP_CONTEXT = 1
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowCUDAContext, garrow_cuda_context, G_TYPE_OBJECT)
+
+#define GARROW_CUDA_CONTEXT_GET_PRIVATE(object)                                          \
+  static_cast<GArrowCUDAContextPrivate *>(                                               \
+    garrow_cuda_context_get_instance_private(GARROW_CUDA_CONTEXT(object)))
+
+static void
+garrow_cuda_context_finalize(GObject *object)
+{
+  auto priv = GARROW_CUDA_CONTEXT_GET_PRIVATE(object);
+
+  priv->context.~shared_ptr();
+
+  G_OBJECT_CLASS(garrow_cuda_context_parent_class)->finalize(object);
+}
+
+static void
+garrow_cuda_context_set_property(GObject *object,
+                                 guint prop_id,
+                                 const GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto priv = GARROW_CUDA_CONTEXT_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_CONTEXT:
+    priv->context = *static_cast<std::shared_ptr<arrow::cuda::CudaContext> *>(
+      g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_cuda_context_get_property(GObject *object,
+                                 guint prop_id,
+                                 GValue *value,
+                                 GParamSpec *pspec)
+{
+  switch (prop_id) {
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_cuda_context_init(GArrowCUDAContext *object)
+{
+  auto priv = GARROW_CUDA_CONTEXT_GET_PRIVATE(object);
+  new (&priv->context) std::shared_ptr<arrow::cuda::CudaContext>;
+}
+
+static void
+garrow_cuda_context_class_init(GArrowCUDAContextClass *klass)
+{
+  GParamSpec *spec;
+
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = garrow_cuda_context_finalize;
+  gobject_class->set_property = garrow_cuda_context_set_property;
+  gobject_class->get_property = garrow_cuda_context_get_property;
+
+  /**
+   * GArrowCUDAContext:context:
+   *
+   * Since: 0.8.0
+   */
+  spec = g_param_spec_pointer(
+    "context",
+    "Context",
+    "The raw std::shared_ptr<arrow::cuda::CudaContext>",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_CONTEXT, spec);
+}
+
+/**
+ * garrow_cuda_context_get_allocated_size:
+ * @context: A #GArrowCUDAContext.
+ *
+ * Returns: The allocated memory by this context in bytes.
+ *
+ * Since: 0.8.0
+ */
+gint64
+garrow_cuda_context_get_allocated_size(GArrowCUDAContext *context)
+{
+  auto arrow_context = garrow_cuda_context_get_raw(context);
+  return arrow_context->bytes_allocated();
+}
+
+G_DEFINE_TYPE(GArrowCUDABuffer, garrow_cuda_buffer, GARROW_TYPE_BUFFER)
+
+static void
+garrow_cuda_buffer_init(GArrowCUDABuffer *object)
+{
+}
+
+static void
+garrow_cuda_buffer_class_init(GArrowCUDABufferClass *klass)
+{
+}
+
+/**
+ * garrow_cuda_buffer_new:
+ * @context: A #GArrowCUDAContext.
+ * @size: The number of bytes to be allocated on GPU device for this context.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): A newly created #GArrowCUDABuffer on
+ *   success, %NULL on error.
+ *
+ * Since: 0.8.0
+ */
+GArrowCUDABuffer *
+garrow_cuda_buffer_new(GArrowCUDAContext *context, gint64 size, GError **error)
+{
+  auto arrow_context = garrow_cuda_context_get_raw(context);
+  auto arrow_buffer_result = arrow_context->Allocate(size);
+  if (garrow::check(error, arrow_buffer_result, "[cuda][buffer][new]")) {
+    std::shared_ptr<arrow::cuda::CudaBuffer> arrow_buffer =
+      std::move(*arrow_buffer_result);
+    return garrow_cuda_buffer_new_raw(&arrow_buffer);
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * garrow_cuda_buffer_new_ipc:
+ * @context: A #GArrowCUDAContext.
+ * @handle: A #GArrowCUDAIPCMemoryHandle to be communicated.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): A newly created #GArrowCUDABuffer on
+ *   success, %NULL on error. The buffer has data from the IPC target.
+ *
+ * Since: 0.8.0
+ */
+GArrowCUDABuffer *
+garrow_cuda_buffer_new_ipc(GArrowCUDAContext *context,
+                           GArrowCUDAIPCMemoryHandle *handle,
+                           GError **error)
+{
+  auto arrow_context = garrow_cuda_context_get_raw(context);
+  auto arrow_handle = garrow_cuda_ipc_memory_handle_get_raw(handle);
+  auto arrow_buffer = arrow_context->OpenIpcBuffer(*arrow_handle);
+  if (garrow::check(error, arrow_buffer, "[cuda][buffer][new-ipc]")) {
+    return garrow_cuda_buffer_new_raw(&(*arrow_buffer));
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * garrow_cuda_buffer_new_record_batch:
+ * @context: A #GArrowCUDAContext.
+ * @record_batch: A #GArrowRecordBatch to be serialized.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): A newly created #GArrowCUDABuffer on
+ *   success, %NULL on error. The buffer has serialized record batch
+ *   data.
+ *
+ * Since: 0.8.0
+ */
+GArrowCUDABuffer *
+garrow_cuda_buffer_new_record_batch(GArrowCUDAContext *context,
+                                    GArrowRecordBatch *record_batch,
+                                    GError **error)
+{
+  auto arrow_context = garrow_cuda_context_get_raw(context);
+  auto arrow_record_batch = garrow_record_batch_get_raw(record_batch);
+  auto arrow_buffer =
+    arrow::cuda::SerializeRecordBatch(*arrow_record_batch, arrow_context.get());
+  if (garrow::check(error, arrow_buffer, "[cuda][buffer][new-record-batch]")) {
+    return garrow_cuda_buffer_new_raw(&(*arrow_buffer));
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * garrow_cuda_buffer_copy_to_host:
+ * @buffer: A #GArrowCUDABuffer.
+ * @position: The offset of memory on GPU device to be copied.
+ * @size: The size of memory on GPU device to be copied in bytes.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): A #GBytes that have copied memory on CPU
+ *   host on success, %NULL on error.
+ *
+ * Since: 0.8.0
+ */
+GBytes *
+garrow_cuda_buffer_copy_to_host(GArrowCUDABuffer *buffer,
+                                gint64 position,
+                                gint64 size,
+                                GError **error)
+{
+  auto arrow_buffer = garrow_cuda_buffer_get_raw(buffer);
+  auto data = static_cast<uint8_t *>(g_malloc(size));
+  auto status = arrow_buffer->CopyToHost(position, size, data);
+  if (garrow_error_check(error, status, "[cuda][buffer][copy-to-host]")) {
+    return g_bytes_new_take(data, size);
+  } else {
+    g_free(data);
+    return NULL;
+  }
+}
+
+/**
+ * garrow_cuda_buffer_copy_from_host:
+ * @buffer: A #GArrowCUDABuffer.
+ * @data: (array length=size): Data on CPU host to be copied.
+ * @size: The size of data on CPU host to be copied in bytes.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.8.0
+ */
+gboolean
+garrow_cuda_buffer_copy_from_host(GArrowCUDABuffer *buffer,
+                                  const guint8 *data,
+                                  gint64 size,
+                                  GError **error)
+{
+  auto arrow_buffer = garrow_cuda_buffer_get_raw(buffer);
+  auto status = arrow_buffer->CopyFromHost(0, data, size);
+  return garrow_error_check(error, status, "[cuda][buffer][copy-from-host]");
+}
+
+/**
+ * garrow_cuda_buffer_export:
+ * @buffer: A #GArrowCUDABuffer.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): A newly created
+ *   #GArrowCUDAIPCMemoryHandle to handle the exported buffer on
+ *   success, %NULL on error
+ *
+ * Since: 0.8.0
+ */
+GArrowCUDAIPCMemoryHandle *
+garrow_cuda_buffer_export(GArrowCUDABuffer *buffer, GError **error)
+{
+  auto arrow_buffer = garrow_cuda_buffer_get_raw(buffer);
+  auto arrow_handle = arrow_buffer->ExportForIpc();
+  if (garrow::check(error, arrow_handle, "[cuda][buffer][export-for-ipc]")) {
+    return garrow_cuda_ipc_memory_handle_new_raw(&(*arrow_handle));
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * garrow_cuda_buffer_get_context:
+ * @buffer: A #GArrowCUDABuffer.
+ *
+ * Returns: (transfer full): A newly created #GArrowCUDAContext for the
+ *   buffer. Contexts for the same buffer share the same data internally.
+ *
+ * Since: 0.8.0
+ */
+GArrowCUDAContext *
+garrow_cuda_buffer_get_context(GArrowCUDABuffer *buffer)
+{
+  auto arrow_buffer = garrow_cuda_buffer_get_raw(buffer);
+  auto arrow_context = arrow_buffer->context();
+  return garrow_cuda_context_new_raw(&arrow_context);
+}
+
+/**
+ * garrow_cuda_buffer_read_record_batch:
+ * @buffer: A #GArrowCUDABuffer.
+ * @schema: A #GArrowSchema for record batch.
+ * @options: (nullable): A #GArrowReadOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): A newly created #GArrowRecordBatch on
+ *   success, %NULL on error. The record batch data is located on GPU.
+ *
+ * Since: 0.8.0
+ */
+GArrowRecordBatch *
+garrow_cuda_buffer_read_record_batch(GArrowCUDABuffer *buffer,
+                                     GArrowSchema *schema,
+                                     GArrowReadOptions *options,
+                                     GError **error)
+{
+  auto arrow_buffer = garrow_cuda_buffer_get_raw(buffer);
+  auto arrow_schema = garrow_schema_get_raw(schema);
+
+  if (options) {
+    auto arrow_options = garrow_read_options_get_raw(options);
+    auto arrow_dictionary_memo = garrow_read_options_get_dictionary_memo_raw(options);
+    auto arrow_record_batch = arrow::cuda::ReadRecordBatch(arrow_schema,
+                                                           arrow_dictionary_memo,
+                                                           arrow_buffer,
+                                                           arrow_options->memory_pool);
+    if (garrow::check(error, arrow_record_batch, "[cuda][buffer][read-record-batch]")) {
+      return garrow_record_batch_new_raw(&(*arrow_record_batch));
+    } else {
+      return NULL;
+    }
+  } else {
+    auto arrow_pool = arrow::default_memory_pool();
+    auto arrow_record_batch =
+      arrow::cuda::ReadRecordBatch(arrow_schema, nullptr, arrow_buffer, arrow_pool);
+    if (garrow::check(error, arrow_record_batch, "[cuda][buffer][read-record-batch]")) {
+      return garrow_record_batch_new_raw(&(*arrow_record_batch));
+    } else {
+      return NULL;
+    }
+  }
+}
+
+G_DEFINE_TYPE(GArrowCUDAHostBuffer, garrow_cuda_host_buffer, GARROW_TYPE_MUTABLE_BUFFER)
+
+static void
+garrow_cuda_host_buffer_init(GArrowCUDAHostBuffer *object)
+{
+}
+
+static void
+garrow_cuda_host_buffer_class_init(GArrowCUDAHostBufferClass *klass)
+{
+}
+
+/**
+ * garrow_cuda_host_buffer_new:
+ * @gpu_number: A GPU device number for the target context.
+ * @size: The number of bytes to be allocated on CPU host.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: A newly created #GArrowCUDAHostBuffer on success,
+ *   %NULL on error. The allocated memory is accessible from GPU
+ *   device for the @context.
+ *
+ * Since: 0.8.0
+ */
+GArrowCUDAHostBuffer *
+garrow_cuda_host_buffer_new(gint gpu_number, gint64 size, GError **error)
+{
+  auto arrow_manager = arrow::cuda::CudaDeviceManager::Instance();
+  auto arrow_buffer = (*arrow_manager)->AllocateHost(gpu_number, size);
+  if (garrow::check(error, arrow_buffer, "[cuda][host-buffer][new]")) {
+    return garrow_cuda_host_buffer_new_raw(&(*arrow_buffer));
+  } else {
+    return NULL;
+  }
+}
+
+typedef struct GArrowCUDAIPCMemoryHandlePrivate_
+{
+  std::shared_ptr<arrow::cuda::CudaIpcMemHandle> ipc_memory_handle;
+} GArrowCUDAIPCMemoryHandlePrivate;
+
+enum {
+  PROP_IPC_MEMORY_HANDLE = 1
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowCUDAIPCMemoryHandle,
+                           garrow_cuda_ipc_memory_handle,
+                           G_TYPE_OBJECT)
+
+#define GARROW_CUDA_IPC_MEMORY_HANDLE_GET_PRIVATE(object)                                \
+  static_cast<GArrowCUDAIPCMemoryHandlePrivate *>(                                       \
+    garrow_cuda_ipc_memory_handle_get_instance_private(                                  \
+      GARROW_CUDA_IPC_MEMORY_HANDLE(object)))
+
+static void
+garrow_cuda_ipc_memory_handle_finalize(GObject *object)
+{
+  auto priv = GARROW_CUDA_IPC_MEMORY_HANDLE_GET_PRIVATE(object);
+
+  priv->ipc_memory_handle = nullptr;
+
+  G_OBJECT_CLASS(garrow_cuda_ipc_memory_handle_parent_class)->finalize(object);
+}
+
+static void
+garrow_cuda_ipc_memory_handle_set_property(GObject *object,
+                                           guint prop_id,
+                                           const GValue *value,
+                                           GParamSpec *pspec)
+{
+  auto priv = GARROW_CUDA_IPC_MEMORY_HANDLE_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_IPC_MEMORY_HANDLE:
+    priv->ipc_memory_handle =
+      *static_cast<std::shared_ptr<arrow::cuda::CudaIpcMemHandle> *>(
+        g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_cuda_ipc_memory_handle_get_property(GObject *object,
+                                           guint prop_id,
+                                           GValue *value,
+                                           GParamSpec *pspec)
+{
+  switch (prop_id) {
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_cuda_ipc_memory_handle_init(GArrowCUDAIPCMemoryHandle *object)
+{
+}
+
+static void
+garrow_cuda_ipc_memory_handle_class_init(GArrowCUDAIPCMemoryHandleClass *klass)
+{
+  GParamSpec *spec;
+
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = garrow_cuda_ipc_memory_handle_finalize;
+  gobject_class->set_property = garrow_cuda_ipc_memory_handle_set_property;
+  gobject_class->get_property = garrow_cuda_ipc_memory_handle_get_property;
+
+  /**
+   * GArrowCUDAIPCMemoryHandle:ipc-memory-handle:
+   *
+   * Since: 0.8.0
+   */
+  spec = g_param_spec_pointer(
+    "ipc-memory-handle",
+    "IPC Memory Handle",
+    "The raw std::shared_ptr<arrow::cuda::CudaIpcMemHandle>",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_IPC_MEMORY_HANDLE, spec);
+}
+
+/**
+ * garrow_cuda_ipc_memory_handle_new:
+ * @data: (array length=size): A serialized #GArrowCUDAIPCMemoryHandle.
+ * @size: The size of data.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): A newly created #GArrowCUDAIPCMemoryHandle
+ *   on success, %NULL on error.
+ *
+ * Since: 0.8.0
+ */
+GArrowCUDAIPCMemoryHandle *
+garrow_cuda_ipc_memory_handle_new(const guint8 *data, gsize size, GError **error)
+{
+  auto arrow_handle = arrow::cuda::CudaIpcMemHandle::FromBuffer(data);
+  if (garrow::check(error, arrow_handle, "[cuda][ipc-memory-handle][new]")) {
+    return garrow_cuda_ipc_memory_handle_new_raw(&(*arrow_handle));
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * garrow_cuda_ipc_memory_handle_serialize:
+ * @handle: A #GArrowCUDAIPCMemoryHandle.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): A newly created #GArrowBuffer on success,
+ *   %NULL on error. The buffer has serialized @handle. The serialized
+ *   @handle can be deserialized by garrow_cuda_ipc_memory_handle_new()
+ *   in other process.
+ *
+ * Since: 0.8.0
+ */
+GArrowBuffer *
+garrow_cuda_ipc_memory_handle_serialize(GArrowCUDAIPCMemoryHandle *handle, GError **error)
+{
+  auto arrow_handle = garrow_cuda_ipc_memory_handle_get_raw(handle);
+  auto arrow_buffer = arrow_handle->Serialize(arrow::default_memory_pool());
+  if (garrow::check(error, arrow_buffer, "[cuda][ipc-memory-handle][serialize]")) {
+    return garrow_buffer_new_raw(&(*arrow_buffer));
+  } else {
+    return NULL;
+  }
+}
+
+static GArrowBuffer *
+garrow_cuda_buffer_input_stream_buffer_new_raw_readable_interface(
+  std::shared_ptr<arrow::Buffer> *arrow_buffer)
+{
+  auto arrow_cuda_buffer =
+    reinterpret_cast<std::shared_ptr<arrow::cuda::CudaBuffer> *>(arrow_buffer);
+  auto cuda_buffer = garrow_cuda_buffer_new_raw(arrow_cuda_buffer);
+  return GARROW_BUFFER(cuda_buffer);
+}
+
+static std::shared_ptr<arrow::io::Readable>
+garrow_cuda_buffer_input_stream_get_raw_readable_interface(GArrowReadable *readable)
+{
+  auto input_stream = GARROW_INPUT_STREAM(readable);
+  auto arrow_input_stream = garrow_input_stream_get_raw(input_stream);
+  return arrow_input_stream;
+}
+
+static void
+garrow_cuda_buffer_input_stream_readable_interface_init(GArrowReadableInterface *iface)
+{
+  iface->buffer_new_raw =
+    garrow_cuda_buffer_input_stream_buffer_new_raw_readable_interface;
+  iface->get_raw = garrow_cuda_buffer_input_stream_get_raw_readable_interface;
+}
+
+G_DEFINE_TYPE_WITH_CODE(
+  GArrowCUDABufferInputStream,
+  garrow_cuda_buffer_input_stream,
+  GARROW_TYPE_BUFFER_INPUT_STREAM,
+  G_IMPLEMENT_INTERFACE(GARROW_TYPE_READABLE,
+                        garrow_cuda_buffer_input_stream_readable_interface_init))
+
+static void
+garrow_cuda_buffer_input_stream_init(GArrowCUDABufferInputStream *object)
+{
+}
+
+static void
+garrow_cuda_buffer_input_stream_class_init(GArrowCUDABufferInputStreamClass *klass)
+{
+}
+
+/**
+ * garrow_cuda_buffer_input_stream_new:
+ * @buffer: A #GArrowCUDABuffer.
+ *
+ * Returns: (transfer full): A newly created
+ *   #GArrowCUDABufferInputStream.
+ *
+ * Since: 0.8.0
+ */
+GArrowCUDABufferInputStream *
+garrow_cuda_buffer_input_stream_new(GArrowCUDABuffer *buffer)
+{
+  auto arrow_buffer = garrow_cuda_buffer_get_raw(buffer);
+  auto arrow_reader = std::make_shared<arrow::cuda::CudaBufferReader>(arrow_buffer);
+  return garrow_cuda_buffer_input_stream_new_raw(&arrow_reader);
+}
+
+G_DEFINE_TYPE(GArrowCUDABufferOutputStream,
+              garrow_cuda_buffer_output_stream,
+              GARROW_TYPE_OUTPUT_STREAM)
+
+static void
+garrow_cuda_buffer_output_stream_init(GArrowCUDABufferOutputStream *object)
+{
+}
+
+static void
+garrow_cuda_buffer_output_stream_class_init(GArrowCUDABufferOutputStreamClass *klass)
+{
+}
+
+/**
+ * garrow_cuda_buffer_output_stream_new:
+ * @buffer: A #GArrowCUDABuffer.
+ *
+ * Returns: (transfer full): A newly created
+ *   #GArrowCUDABufferOutputStream.
+ *
+ * Since: 0.8.0
+ */
+GArrowCUDABufferOutputStream *
+garrow_cuda_buffer_output_stream_new(GArrowCUDABuffer *buffer)
+{
+  auto arrow_buffer = garrow_cuda_buffer_get_raw(buffer);
+  auto arrow_writer = std::make_shared<arrow::cuda::CudaBufferWriter>(arrow_buffer);
+  return garrow_cuda_buffer_output_stream_new_raw(&arrow_writer);
+}
+
+/**
+ * garrow_cuda_buffer_output_stream_set_buffer_size:
+ * @stream: A #GArrowCUDABufferOutputStream.
+ * @size: A size of CPU buffer in bytes.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Sets CPU buffer size. to limit `cudaMemcpy()` calls. If CPU buffer
+ * size is `0`, buffering is disabled.
+ *
+ * The default is `0`.
+ *
+ * Since: 0.8.0
+ */
+gboolean
+garrow_cuda_buffer_output_stream_set_buffer_size(GArrowCUDABufferOutputStream *stream,
+                                                 gint64 size,
+                                                 GError **error)
+{
+  auto arrow_stream = garrow_cuda_buffer_output_stream_get_raw(stream);
+  auto status = arrow_stream->SetBufferSize(size);
+  return garrow_error_check(error,
+                            status,
+                            "[cuda][buffer-output-stream][set-buffer-size]");
+}
+
+/**
+ * garrow_cuda_buffer_output_stream_get_buffer_size:
+ * @stream: A #GArrowCUDABufferOutputStream.
+ *
+ * Returns: The CPU buffer size in bytes.
+ *
+ * See garrow_cuda_buffer_output_stream_set_buffer_size() for CPU
+ * buffer size details.
+ *
+ * Since: 0.8.0
+ */
+gint64
+garrow_cuda_buffer_output_stream_get_buffer_size(GArrowCUDABufferOutputStream *stream)
+{
+  auto arrow_stream = garrow_cuda_buffer_output_stream_get_raw(stream);
+  return arrow_stream->buffer_size();
+}
+
+/**
+ * garrow_cuda_buffer_output_stream_get_buffered_size:
+ * @stream: A #GArrowCUDABufferOutputStream.
+ *
+ * Returns: The size of buffered data in bytes.
+ *
+ * Since: 0.8.0
+ */
+gint64
+garrow_cuda_buffer_output_stream_get_buffered_size(GArrowCUDABufferOutputStream *stream)
+{
+  auto arrow_stream = garrow_cuda_buffer_output_stream_get_raw(stream);
+  return arrow_stream->num_bytes_buffered();
+}
+
+G_END_DECLS
+
+GArrowCUDAContext *
+garrow_cuda_context_new_raw(std::shared_ptr<arrow::cuda::CudaContext> *arrow_context)
+{
+  return GARROW_CUDA_CONTEXT(
+    g_object_new(GARROW_CUDA_TYPE_CONTEXT, "context", arrow_context, NULL));
+}
+
+std::shared_ptr<arrow::cuda::CudaContext>
+garrow_cuda_context_get_raw(GArrowCUDAContext *context)
+{
+  if (!context)
+    return nullptr;
+
+  auto priv = GARROW_CUDA_CONTEXT_GET_PRIVATE(context);
+  return priv->context;
+}
+
+GArrowCUDAIPCMemoryHandle *
+garrow_cuda_ipc_memory_handle_new_raw(
+  std::shared_ptr<arrow::cuda::CudaIpcMemHandle> *arrow_handle)
+{
+  auto handle = g_object_new(GARROW_CUDA_TYPE_IPC_MEMORY_HANDLE,
+                             "ipc-memory-handle",
+                             arrow_handle,
+                             NULL);
+  return GARROW_CUDA_IPC_MEMORY_HANDLE(handle);
+}
+
+std::shared_ptr<arrow::cuda::CudaIpcMemHandle>
+garrow_cuda_ipc_memory_handle_get_raw(GArrowCUDAIPCMemoryHandle *handle)
+{
+  if (!handle)
+    return nullptr;
+
+  auto priv = GARROW_CUDA_IPC_MEMORY_HANDLE_GET_PRIVATE(handle);
+  return priv->ipc_memory_handle;
+}
+
+GArrowCUDABuffer *
+garrow_cuda_buffer_new_raw(std::shared_ptr<arrow::cuda::CudaBuffer> *arrow_buffer)
+{
+  return GARROW_CUDA_BUFFER(
+    g_object_new(GARROW_CUDA_TYPE_BUFFER, "buffer", arrow_buffer, NULL));
+}
+
+std::shared_ptr<arrow::cuda::CudaBuffer>
+garrow_cuda_buffer_get_raw(GArrowCUDABuffer *buffer)
+{
+  if (!buffer)
+    return nullptr;
+
+  auto arrow_buffer = garrow_buffer_get_raw(GARROW_BUFFER(buffer));
+  return std::static_pointer_cast<arrow::cuda::CudaBuffer>(arrow_buffer);
+}
+
+GArrowCUDAHostBuffer *
+garrow_cuda_host_buffer_new_raw(
+  std::shared_ptr<arrow::cuda::CudaHostBuffer> *arrow_buffer)
+{
+  auto buffer = g_object_new(GARROW_CUDA_TYPE_HOST_BUFFER, "buffer", arrow_buffer, NULL);
+  return GARROW_CUDA_HOST_BUFFER(buffer);
+}
+
+std::shared_ptr<arrow::cuda::CudaHostBuffer>
+garrow_cuda_host_buffer_get_raw(GArrowCUDAHostBuffer *buffer)
+{
+  if (!buffer)
+    return nullptr;
+
+  auto arrow_buffer = garrow_buffer_get_raw(GARROW_BUFFER(buffer));
+  return std::static_pointer_cast<arrow::cuda::CudaHostBuffer>(arrow_buffer);
+}
+
+GArrowCUDABufferInputStream *
+garrow_cuda_buffer_input_stream_new_raw(
+  std::shared_ptr<arrow::cuda::CudaBufferReader> *arrow_reader)
+{
+  auto input_stream = g_object_new(GARROW_CUDA_TYPE_BUFFER_INPUT_STREAM,
+                                   "input-stream",
+                                   arrow_reader,
+                                   NULL);
+  return GARROW_CUDA_BUFFER_INPUT_STREAM(input_stream);
+}
+
+std::shared_ptr<arrow::cuda::CudaBufferReader>
+garrow_cuda_buffer_input_stream_get_raw(GArrowCUDABufferInputStream *input_stream)
+{
+  if (!input_stream)
+    return nullptr;
+
+  auto arrow_reader = garrow_input_stream_get_raw(GARROW_INPUT_STREAM(input_stream));
+  return std::static_pointer_cast<arrow::cuda::CudaBufferReader>(arrow_reader);
+}
+
+GArrowCUDABufferOutputStream *
+garrow_cuda_buffer_output_stream_new_raw(
+  std::shared_ptr<arrow::cuda::CudaBufferWriter> *arrow_writer)
+{
+  auto output_stream = g_object_new(GARROW_CUDA_TYPE_BUFFER_OUTPUT_STREAM,
+                                    "output-stream",
+                                    arrow_writer,
+                                    NULL);
+  return GARROW_CUDA_BUFFER_OUTPUT_STREAM(output_stream);
+}
+
+std::shared_ptr<arrow::cuda::CudaBufferWriter>
+garrow_cuda_buffer_output_stream_get_raw(GArrowCUDABufferOutputStream *output_stream)
+{
+  if (!output_stream)
+    return nullptr;
+
+  auto arrow_writer = garrow_output_stream_get_raw(GARROW_OUTPUT_STREAM(output_stream));
+  return std::static_pointer_cast<arrow::cuda::CudaBufferWriter>(arrow_writer);
+}

--- a/cpp/file-format.cpp
+++ b/cpp/file-format.cpp
@@ -1,0 +1,546 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <arrow-glib/error.hpp>
+#include <arrow-glib/file-system.hpp>
+#include <arrow-glib/output-stream.hpp>
+#include <arrow-glib/record-batch.hpp>
+#include <arrow-glib/reader.hpp>
+#include <arrow-glib/schema.hpp>
+
+#include <arrow-dataset-glib/file-format.hpp>
+
+G_BEGIN_DECLS
+
+/**
+ * SECTION: file-format
+ * @section_id: file-format
+ * @title: File format classes
+ * @include: arrow-dataset-glib/arrow-dataset-glib.h
+ *
+ * #GADatasetFileWriteOptions is a class for options to write a file
+ * of this format.
+ *
+ * #GADatasetFileWriter is a class for writing a file of this format.
+ *
+ * #GADatasetFileFormat is a base class for file format classes.
+ *
+ * #GADatasetCSVFileFormat is a class for CSV file format.
+ *
+ * #GADatasetIPCFileFormat is a class for IPC file format.
+ *
+ * #GADatasetParquetFileFormat is a class for Parquet file format.
+ *
+ * Since: 3.0.0
+ */
+
+typedef struct GADatasetFileWriteOptionsPrivate_
+{
+  std::shared_ptr<arrow::dataset::FileWriteOptions> options;
+} GADatasetFileWriteOptionsPrivate;
+
+enum {
+  PROP_OPTIONS = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GADatasetFileWriteOptions,
+                           gadataset_file_write_options,
+                           G_TYPE_OBJECT)
+
+#define GADATASET_FILE_WRITE_OPTIONS_GET_PRIVATE(obj)                                    \
+  static_cast<GADatasetFileWriteOptionsPrivate *>(                                       \
+    gadataset_file_write_options_get_instance_private(                                   \
+      GADATASET_FILE_WRITE_OPTIONS(obj)))
+
+static void
+gadataset_file_write_options_finalize(GObject *object)
+{
+  auto priv = GADATASET_FILE_WRITE_OPTIONS_GET_PRIVATE(object);
+  priv->options.~shared_ptr();
+  G_OBJECT_CLASS(gadataset_file_write_options_parent_class)->finalize(object);
+}
+
+static void
+gadataset_file_write_options_set_property(GObject *object,
+                                          guint prop_id,
+                                          const GValue *value,
+                                          GParamSpec *pspec)
+{
+  auto priv = GADATASET_FILE_WRITE_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_OPTIONS:
+    priv->options = *static_cast<std::shared_ptr<arrow::dataset::FileWriteOptions> *>(
+      g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gadataset_file_write_options_init(GADatasetFileWriteOptions *object)
+{
+  auto priv = GADATASET_FILE_WRITE_OPTIONS_GET_PRIVATE(object);
+  new (&priv->options) std::shared_ptr<arrow::dataset::FileWriteOptions>;
+}
+
+static void
+gadataset_file_write_options_class_init(GADatasetFileWriteOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gadataset_file_write_options_finalize;
+  gobject_class->set_property = gadataset_file_write_options_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "options",
+    "Options",
+    "The raw "
+    "std::shared<arrow::dataset::FileWriteOptions> *",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_OPTIONS, spec);
+}
+
+typedef struct GADatasetFileWriterPrivate_
+{
+  std::shared_ptr<arrow::dataset::FileWriter> writer;
+} GADatasetFileWriterPrivate;
+
+enum {
+  PROP_WRITER = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GADatasetFileWriter, gadataset_file_writer, G_TYPE_OBJECT)
+
+#define GADATASET_FILE_WRITER_GET_PRIVATE(obj)                                           \
+  static_cast<GADatasetFileWriterPrivate *>(                                             \
+    gadataset_file_writer_get_instance_private(GADATASET_FILE_WRITER(obj)))
+
+static void
+gadataset_file_writer_finalize(GObject *object)
+{
+  auto priv = GADATASET_FILE_WRITER_GET_PRIVATE(object);
+  priv->writer.~shared_ptr();
+  G_OBJECT_CLASS(gadataset_file_writer_parent_class)->finalize(object);
+}
+
+static void
+gadataset_file_writer_set_property(GObject *object,
+                                   guint prop_id,
+                                   const GValue *value,
+                                   GParamSpec *pspec)
+{
+  auto priv = GADATASET_FILE_WRITER_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_WRITER:
+    priv->writer = *static_cast<std::shared_ptr<arrow::dataset::FileWriter> *>(
+      g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gadataset_file_writer_init(GADatasetFileWriter *object)
+{
+  auto priv = GADATASET_FILE_WRITER_GET_PRIVATE(object);
+  new (&(priv->writer)) std::shared_ptr<arrow::dataset::FileWriter>;
+}
+
+static void
+gadataset_file_writer_class_init(GADatasetFileWriterClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gadataset_file_writer_finalize;
+  gobject_class->set_property = gadataset_file_writer_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "writer",
+    "Writer",
+    "The raw "
+    "std::shared<arrow::dataset::FileWriter> *",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_WRITER, spec);
+}
+
+/**
+ * gadataset_file_writer_write_record_batch:
+ * @writer: A #GADatasetFileWriter.
+ * @record_batch: A #GArrowRecordBatch to be written.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 6.0.0
+ */
+gboolean
+gadataset_file_writer_write_record_batch(GADatasetFileWriter *writer,
+                                         GArrowRecordBatch *record_batch,
+                                         GError **error)
+{
+  const auto arrow_writer = gadataset_file_writer_get_raw(writer);
+  const auto arrow_record_batch = garrow_record_batch_get_raw(record_batch);
+  auto status = arrow_writer->Write(arrow_record_batch);
+  return garrow::check(error, status, "[file-writer][write-record-batch]");
+}
+
+/**
+ * gadataset_file_writer_write_record_batch_reader:
+ * @writer: A #GADatasetFileWriter.
+ * @reader: A #GArrowRecordBatchReader to be written.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 6.0.0
+ */
+gboolean
+gadataset_file_writer_write_record_batch_reader(GADatasetFileWriter *writer,
+                                                GArrowRecordBatchReader *reader,
+                                                GError **error)
+{
+  const auto arrow_writer = gadataset_file_writer_get_raw(writer);
+  auto arrow_reader = garrow_record_batch_reader_get_raw(reader);
+  auto status = arrow_writer->Write(arrow_reader.get());
+  return garrow::check(error, status, "[file-writer][write-record-batch-reader]");
+}
+
+/**
+ * gadataset_file_writer_finish:
+ * @writer: A #GADatasetFileWriter.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 6.0.0
+ */
+gboolean
+gadataset_file_writer_finish(GADatasetFileWriter *writer, GError **error)
+{
+  const auto arrow_writer = gadataset_file_writer_get_raw(writer);
+  auto status = arrow_writer->Finish().status();
+  return garrow::check(error, status, "[file-writer][finish]");
+}
+
+typedef struct GADatasetFileFormatPrivate_
+{
+  std::shared_ptr<arrow::dataset::FileFormat> format;
+} GADatasetFileFormatPrivate;
+
+enum {
+  PROP_FORMAT = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GADatasetFileFormat, gadataset_file_format, G_TYPE_OBJECT)
+
+#define GADATASET_FILE_FORMAT_GET_PRIVATE(obj)                                           \
+  static_cast<GADatasetFileFormatPrivate *>(                                             \
+    gadataset_file_format_get_instance_private(GADATASET_FILE_FORMAT(obj)))
+
+static void
+gadataset_file_format_finalize(GObject *object)
+{
+  auto priv = GADATASET_FILE_FORMAT_GET_PRIVATE(object);
+  priv->format.~shared_ptr();
+  G_OBJECT_CLASS(gadataset_file_format_parent_class)->finalize(object);
+}
+
+static void
+gadataset_file_format_set_property(GObject *object,
+                                   guint prop_id,
+                                   const GValue *value,
+                                   GParamSpec *pspec)
+{
+  auto priv = GADATASET_FILE_FORMAT_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_FORMAT:
+    priv->format = *static_cast<std::shared_ptr<arrow::dataset::FileFormat> *>(
+      g_value_get_pointer(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gadataset_file_format_init(GADatasetFileFormat *object)
+{
+  auto priv = GADATASET_FILE_FORMAT_GET_PRIVATE(object);
+  new (&priv->format) std::shared_ptr<arrow::dataset::FileFormat>;
+}
+
+static void
+gadataset_file_format_class_init(GADatasetFileFormatClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gadataset_file_format_finalize;
+  gobject_class->set_property = gadataset_file_format_set_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_pointer(
+    "format",
+    "Format",
+    "The raw std::shared<arrow::dataset::FileFormat> *",
+    static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_FORMAT, spec);
+}
+
+/**
+ * gadataset_file_format_get_type_name:
+ * @format: A #GADatasetFileFormat.
+ *
+ * Returns: The type name of @format.
+ *
+ *   It should be freed with g_free() when no longer needed.
+ *
+ * Since: 3.0.0
+ */
+gchar *
+gadataset_file_format_get_type_name(GADatasetFileFormat *format)
+{
+  const auto arrow_format = gadataset_file_format_get_raw(format);
+  const auto &type_name = arrow_format->type_name();
+  return g_strndup(type_name.data(), type_name.size());
+}
+
+/**
+ * gadataset_file_format_get_default_write_options:
+ * @format: A #GADatasetFileFormat.
+ *
+ * Returns: (transfer full): The default #GADatasetFileWriteOptions of @format.
+ *
+ * Since: 6.0.0
+ */
+GADatasetFileWriteOptions *
+gadataset_file_format_get_default_write_options(GADatasetFileFormat *format)
+{
+  const auto arrow_format = gadataset_file_format_get_raw(format);
+  auto arrow_options = arrow_format->DefaultWriteOptions();
+  return gadataset_file_write_options_new_raw(&arrow_options);
+}
+
+/**
+ * gadataset_file_format_open_writer:
+ * @format: A #GADatasetFileFormat.
+ * @destination: A #GArrowOutputStream.
+ * @file_system: The #GArrowFileSystem of @destination.
+ * @path: The path of @destination.
+ * @schema: A #GArrowSchema that is used by written record batches.
+ * @options: A #GADatasetFileWriteOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): The newly created #GADatasetFileWriter of @format
+ *   on success, %NULL on error.
+ *
+ * Since: 6.0.0
+ */
+GADatasetFileWriter *
+gadataset_file_format_open_writer(GADatasetFileFormat *format,
+                                  GArrowOutputStream *destination,
+                                  GArrowFileSystem *file_system,
+                                  const gchar *path,
+                                  GArrowSchema *schema,
+                                  GADatasetFileWriteOptions *options,
+                                  GError **error)
+{
+  const auto arrow_format = gadataset_file_format_get_raw(format);
+  auto arrow_destination = garrow_output_stream_get_raw(destination);
+  auto arrow_file_system = garrow_file_system_get_raw(file_system);
+  auto arrow_schema = garrow_schema_get_raw(schema);
+  auto arrow_options = gadataset_file_write_options_get_raw(options);
+  auto arrow_writer_result = arrow_format->MakeWriter(arrow_destination,
+                                                      arrow_schema,
+                                                      arrow_options,
+                                                      {arrow_file_system, path});
+  if (garrow::check(error, arrow_writer_result, "[file-format][open-writer]")) {
+    auto arrow_writer = *arrow_writer_result;
+    return gadataset_file_writer_new_raw(&arrow_writer);
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * gadataset_file_format_equal:
+ * @format: A #GADatasetFileFormat.
+ * @other_format: A #GADatasetFileFormat to be compared.
+ *
+ * Returns: %TRUE if they are the same content file format, %FALSE otherwise.
+ *
+ * Since: 3.0.0
+ */
+gboolean
+gadataset_file_format_equal(GADatasetFileFormat *format,
+                            GADatasetFileFormat *other_format)
+{
+  const auto arrow_format = gadataset_file_format_get_raw(format);
+  const auto arrow_other_format = gadataset_file_format_get_raw(other_format);
+  return arrow_format->Equals(*arrow_other_format);
+}
+
+G_DEFINE_TYPE(GADatasetCSVFileFormat,
+              gadataset_csv_file_format,
+              GADATASET_TYPE_FILE_FORMAT)
+
+static void
+gadataset_csv_file_format_init(GADatasetCSVFileFormat *object)
+{
+}
+
+static void
+gadataset_csv_file_format_class_init(GADatasetCSVFileFormatClass *klass)
+{
+}
+
+/**
+ * gadataset_csv_file_format_new:
+ *
+ * Returns: The newly created CSV file format.
+ *
+ * Since: 3.0.0
+ */
+GADatasetCSVFileFormat *
+gadataset_csv_file_format_new(void)
+{
+  std::shared_ptr<arrow::dataset::FileFormat> arrow_format =
+    std::make_shared<arrow::dataset::CsvFileFormat>();
+  return GADATASET_CSV_FILE_FORMAT(gadataset_file_format_new_raw(&arrow_format));
+}
+
+G_DEFINE_TYPE(GADatasetIPCFileFormat,
+              gadataset_ipc_file_format,
+              GADATASET_TYPE_FILE_FORMAT)
+
+static void
+gadataset_ipc_file_format_init(GADatasetIPCFileFormat *object)
+{
+}
+
+static void
+gadataset_ipc_file_format_class_init(GADatasetIPCFileFormatClass *klass)
+{
+}
+
+/**
+ * gadataset_ipc_file_format_new:
+ *
+ * Returns: The newly created IPC file format.
+ *
+ * Since: 3.0.0
+ */
+GADatasetIPCFileFormat *
+gadataset_ipc_file_format_new(void)
+{
+  std::shared_ptr<arrow::dataset::FileFormat> arrow_format =
+    std::make_shared<arrow::dataset::IpcFileFormat>();
+  return GADATASET_IPC_FILE_FORMAT(gadataset_file_format_new_raw(&arrow_format));
+}
+
+G_DEFINE_TYPE(GADatasetParquetFileFormat,
+              gadataset_parquet_file_format,
+              GADATASET_TYPE_FILE_FORMAT)
+
+static void
+gadataset_parquet_file_format_init(GADatasetParquetFileFormat *object)
+{
+}
+
+static void
+gadataset_parquet_file_format_class_init(GADatasetParquetFileFormatClass *klass)
+{
+}
+
+/**
+ * gadataset_parquet_file_format_new:
+ *
+ * Returns: The newly created Parquet file format.
+ *
+ * Since: 3.0.0
+ */
+GADatasetParquetFileFormat *
+gadataset_parquet_file_format_new(void)
+{
+  std::shared_ptr<arrow::dataset::FileFormat> arrow_format =
+    std::make_shared<arrow::dataset::ParquetFileFormat>();
+  return GADATASET_PARQUET_FILE_FORMAT(gadataset_file_format_new_raw(&arrow_format));
+}
+
+G_END_DECLS
+
+GADatasetFileWriteOptions *
+gadataset_file_write_options_new_raw(
+  std::shared_ptr<arrow::dataset::FileWriteOptions> *arrow_options)
+{
+  return GADATASET_FILE_WRITE_OPTIONS(
+    g_object_new(GADATASET_TYPE_FILE_WRITE_OPTIONS, "options", arrow_options, NULL));
+}
+
+std::shared_ptr<arrow::dataset::FileWriteOptions>
+gadataset_file_write_options_get_raw(GADatasetFileWriteOptions *options)
+{
+  auto priv = GADATASET_FILE_WRITE_OPTIONS_GET_PRIVATE(options);
+  return priv->options;
+}
+
+GADatasetFileWriter *
+gadataset_file_writer_new_raw(std::shared_ptr<arrow::dataset::FileWriter> *arrow_writer)
+{
+  return GADATASET_FILE_WRITER(
+    g_object_new(GADATASET_TYPE_FILE_WRITER, "writer", arrow_writer, NULL));
+}
+
+std::shared_ptr<arrow::dataset::FileWriter>
+gadataset_file_writer_get_raw(GADatasetFileWriter *writer)
+{
+  auto priv = GADATASET_FILE_WRITER_GET_PRIVATE(writer);
+  return priv->writer;
+}
+
+GADatasetFileFormat *
+gadataset_file_format_new_raw(std::shared_ptr<arrow::dataset::FileFormat> *arrow_format)
+{
+  GType type = GADATASET_TYPE_FILE_FORMAT;
+  const auto &type_name = (*arrow_format)->type_name();
+  if (type_name == "csv") {
+    type = GADATASET_TYPE_CSV_FILE_FORMAT;
+  } else if (type_name == "ipc") {
+    type = GADATASET_TYPE_IPC_FILE_FORMAT;
+  } else if (type_name == "parquet") {
+    type = GADATASET_TYPE_PARQUET_FILE_FORMAT;
+  }
+  return GADATASET_FILE_FORMAT(g_object_new(type, "format", arrow_format, NULL));
+}
+
+std::shared_ptr<arrow::dataset::FileFormat>
+gadataset_file_format_get_raw(GADatasetFileFormat *format)
+{
+  auto priv = GADATASET_FILE_FORMAT_GET_PRIVATE(format);
+  return priv->format;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce new C++ GLib bindings for Arrow Flight (client APIs), shared Flight types, CUDA utilities, and dataset file-format writing (CSV/IPC/Parquet).
> 
> - **Arrow Flight (GLib client)**:
>   - Add client and stream classes in `cpp/client.cpp`: `GAFlightClient`, `GAFlightStreamReader/Writer`, `GAFlightMetadataReader`, `GAFlightCallOptions`, `GAFlightClientOptions`, `GAFlightDoPutResult` with operations (`AuthenticateBasicToken`, `ListFlights`, `GetFlightInfo`, `DoGet`, `DoPut`, `Close`).
> - **Arrow Flight (common types)**:
>   - Implement shared types in `cpp/common.cpp` and `cpp/common_1.cpp`: `GAFlightCriteria`, `GAFlightLocation`, `GAFlightDescriptor` (`Path`/`Command`), `GAFlightTicket`, `GAFlightEndpoint`, `GAFlightInfo`, `GAFlightStreamChunk`, `GAFlightRecordBatchReader/Writer` with helpers for equality, conversion, and read/write.
> - **CUDA support**:
>   - Add `cpp/cuda.cpp`: `GArrowCUDADeviceManager`, `GArrowCUDAContext`, `GArrowCUDABuffer`/`HostBuffer`, `GArrowCUDAIPCMemoryHandle`, buffer I/O streams, record batch serialization, host/device copy, IPC export/import, and buffer sizing APIs.
> - **Dataset file formats**:
>   - Add `cpp/file-format.cpp`: `GADatasetFileFormat` (CSV/IPC/Parquet), `GADatasetFileWriteOptions`, `GADatasetFileWriter` with writer creation (`MakeWriter`), write (batch/reader), and `Finish()`.}
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a3790f2ad2a5b64ecf22639a84831f4283e2703. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds a GLib-based Arrow Flight client API: authenticate, list flights, fetch flight info, and stream data via DoGet/DoPut with configurable call/client options.
  - Introduces supporting types for descriptors, tickets, endpoints, flight info, stream chunks, and record batch readers/writers.
  - Adds CUDA integration: device manager, contexts, GPU buffers, IPC handles, and buffer input/output streams with host/device transfer and record batch (de)serialization.
  - Introduces Dataset file format support (CSV, IPC, Parquet): query format type, get default write options, compare formats, and open writers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->