### PR TITLE
Add KOTLIN vulnerable samples batch 1/1

### DIFF
--- a/kotlin/ktor-web-app-server_Library.kt
+++ b/kotlin/ktor-web-app-server_Library.kt
@@ -1,0 +1,507 @@
+package domain.library
+
+import com.realityexpander.libraryAppContext
+import common.uuid2.IUUID2
+import common.uuid2.UUID2
+import common.uuid2.UUID2Result
+import domain.Context
+import domain.book.Book
+import domain.common.Role
+import domain.library.data.ILibraryInfoRepo
+import domain.library.data.LibraryInfo
+import domain.user.User
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import okhttp3.internal.toImmutableMap
+import util.JsonString
+
+/**
+ * Library Role
+ *
+ * Library is a Role Object that represents a Library in the LibraryApp domain.
+ *
+ * * Only interacts with its own repository, Context, and other Role Objects in the Domain layer.
+ *
+ * @author Chris Athanas (realityexpanderdev@gmail.com)
+ * @since 0.12 Kotlin conversion
+ */
+
+@Serializable(with = LibrarySerializer::class)  // for kotlinx.serialization
+open class Library : Role<LibraryInfo>, IUUID2 {
+    private val repo: ILibraryInfoRepo
+
+    constructor(
+        info: LibraryInfo,
+        context: Context
+    ) : super(info, context) {
+        repo = context.libraryInfoRepo
+
+        context.log.d("Library<Init>", "Library (" + id() + ") created from Info")
+    }
+    constructor(
+        libraryInfoJson: JsonString,
+        clazz: Class<LibraryInfo>,
+        context: Context
+    ) : super(libraryInfoJson, clazz, context) {
+        repo = context.libraryInfoRepo
+
+        context.log.d("Library<Init>", "Library (" + id() + ") created from Json with class: " + clazz.name)
+    }
+    constructor(
+        id: UUID2<Library>,
+        context: Context
+    ) : super(id, context) {
+        repo = context.libraryInfoRepo
+
+        context.log.d("Library<Init>", "Library (" + id() + ") created using id with no Info")
+    }
+    constructor(libraryInfoJson: JsonString, context: Context) : this(libraryInfoJson, LibraryInfo::class.java, context)
+    constructor(context: Context) : this(UUID2.randomUUID2(Library::class.java), context)
+
+    ////////////////////////////////
+    // Published Simple Getters   //
+    ////////////////////////////////
+
+    // Convenience method to get the Type-safe id from the Class
+    final override fun id(): UUID2<Library> {
+        @Suppress("UNCHECKED_CAST")
+        return super.id as UUID2<Library>
+    }
+
+    /////////////////////////////////////
+    // Role/UUID2 Required Overrides  //
+    /////////////////////////////////////
+
+    override suspend fun fetchInfoResult(): Result<LibraryInfo> {
+        // context.log.d(this,"Library (" + this.id.toString() + ") - fetchInfoResult"); // LEAVE for debugging
+        return repo.fetchLibraryInfo(id())
+    }
+
+    override suspend fun updateInfo(updatedInfo: LibraryInfo): Result<LibraryInfo> {
+        // context.log.d(this,"Library (" + this.id.toString() + ") - updateInfo, newInfo: " + newInfo.toString());  // LEAVE for debugging
+
+        // Optimistically Update the Cached LibraryInfo
+        super.updateFetchInfoResult(Result.success(updatedInfo))
+
+        // Update the Repo
+        return repo.updateLibraryInfo(updatedInfo)
+        // return repo.upsertLibraryInfo(updateInfo) // todo should allow insert when updating? And Log a warning?
+    }
+
+    override fun uuid2TypeStr(): String {
+        // Get the Class Inheritance Path from the Class Path
+        return UUID2.calcUUID2TypeStr(this.javaClass)
+    }
+
+    ///////////////////////////////////////////
+    // Library Role Business Logic Methods   //
+    // - Methods to modify it's LibraryInfo  //
+    // - Communicate with other ROle objects //
+    ///////////////////////////////////////////
+
+    open suspend fun checkOutBookToUser(book: Book, user: User): Result<Book> {
+        context.log.d(this, "Library (" + id() + ") - bookId: " + book.id() + ", userId: " + user.id())
+        fetchInfoFailureReason()?.let { return Result.failure(Exception(it)) }
+        if (isUnableToFindOrRegisterUser(user)) return Result.failure(Exception("User is not known, userId: " + user.id()))
+
+        // Note: this calls a wrapper to the User's Account Role object
+        if (!user.isAccountActive()) return Result.failure(Exception("User Account is not Active or not unregistered, userId: " + user.id()))
+        if (!user.isAccountInGoodStanding()) return Result.failure(Exception("User Account is not in Good Standing, userId: " + user.id()))
+
+        // Note: this calls a wrapper to the User's Account Role object
+        if (user.hasReachedMaxAmountOfAcceptedPublicLibraryBooks()) return Result.failure(Exception("User has reached max num Books accepted, userId: " + user.id()))
+        if (user.hasAcceptedBook(book)) return Result.failure(Exception("User has already accepted this Book, userId: " + user.id() + ", bookId: " + book.id()))
+
+        // Get User's AccountInfo object
+        val userAccountInfo = user.accountInfo()
+            ?: return Result.failure(Exception("User AccountInfo is null, userId: " + user.id()))
+
+        // Check User fines are not exceeded
+        if (userAccountInfo.isMaxFineExceeded) return Result.failure(Exception("User has exceeded maximum fines, userId: " + user.id()))
+
+        // Check out Book to User
+        val checkOutBookResult = this.info()?.checkOutPublicLibraryBookToUser(book, user) ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id()))
+        if (checkOutBookResult.isFailure) return Result.failure(checkOutBookResult.exceptionOrNull() ?: Exception("Unknown failure checking out Book, userId: " + user.id() + ", bookId: " + book.id()))
+        val checkedOutBook: Book = checkOutBookResult.getOrThrow()
+
+        // Update Info, since we modified data for this Library
+        val updateInfoResult = updateInfo(this.info()
+            ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id())))
+        return if (updateInfoResult.isFailure)
+            Result.failure((updateInfoResult.exceptionOrNull() ?: Exception("Unknown failure updating LibraryInfo, libraryId: " + id())))
+        else
+            Result.success(checkedOutBook)
+    }
+
+    open suspend fun checkInBookFromUser(book: Book, user: User): Result<Book> {
+        context.log.d(this, "Library (${id()}) - bookId ${book.id()} from userID ${user.id()}")
+        fetchInfoFailureReason()?.let { return Result.failure(Exception(it)) }
+
+        if(book.isBookFromPublicLibrary) {
+            if(isUnableToFindOrRegisterUser(user))
+                return Result.failure(Exception("User is not known, id: " + user.id()))
+
+            val checkInBookResult = this.info()?.checkInPublicLibraryBookFromUser(book, user)
+                ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id()))
+            if (checkInBookResult.isFailure)
+                return Result.failure((checkInBookResult.exceptionOrNull()
+                        ?: Exception("Unknown failure checking in Book, userId: " + user.id() + ", bookId: " + book.id())))
+        } else {
+            val checkInBookResult = this.info()?.checkInPrivateLibraryBookFromUser(book, user)
+                ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id()))
+            if (checkInBookResult.isFailure)
+                return Result.failure(
+                    (checkInBookResult.exceptionOrNull()
+                        ?: Exception("Unknown failure checking in Book, userId: " + user.id() + ", bookId: " + book.id()))
+                )
+        }
+
+        // Update Info, since we modified data for this Library
+        val updateInfoResult = updateInfo(
+            this.info() ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id())))
+        return if (updateInfoResult.isFailure)
+            Result.failure((updateInfoResult.exceptionOrNull()
+                ?: Exception("Unknown failure updating LibraryInfo, libraryId: " + id())))
+        else
+            Result.success(book)
+    }
+
+    suspend fun transferCheckedOutBookSourceLibraryToThisLibrary(bookToTransfer: Book, user: User): Result<Book> {
+        context.log.d(this, "Library (${id()}) - bookId ${bookToTransfer.id()} from userID ${user.id()}")
+        fetchInfoFailureReason()?.let { return Result.failure(Exception(it)) }
+
+        // If book is checked out by any user, check it in first.
+        val bookSourceLibrary = bookToTransfer.sourceLibrary()
+        val curBookUserResult = bookSourceLibrary.findUserOfCheckedOutBook(bookToTransfer)
+        if(curBookUserResult.isFailure) return Result.failure(curBookUserResult.exceptionOrNull()
+            ?: Exception("Error getting user of checked out book, bookId: " + bookToTransfer.id()))
+        val curBookToTransferUser = curBookUserResult.getOrThrow()
+
+        val returnedBookResult = bookSourceLibrary.checkInBookFromUser(bookToTransfer, curBookToTransferUser)
+        if (returnedBookResult.isFailure) return Result.failure(returnedBookResult.exceptionOrNull()
+            ?: Exception("Error checking in book, bookId: " + bookToTransfer.id()))
+
+        // Transfer Book to this Library
+        val transferBookResult = transferBookSourceLibraryToThisLibrary(bookToTransfer)
+        if (transferBookResult.isFailure) return Result.failure((transferBookResult.exceptionOrNull()
+            ?: Exception("Unknown failure transferring Book, userId: " + user.id() + ", bookId: " + bookToTransfer.id())))
+        val transferredBook = transferBookResult.getOrThrow()
+
+        // Check out Book to User from this Library
+        val checkOutBookResult = checkOutBookToUser(transferredBook, user)
+        if (checkOutBookResult.isFailure) return Result.failure((checkOutBookResult.exceptionOrNull()
+            ?: Exception("Unknown failure checking out Book, userId: " + user.id() + ", bookId: " + bookToTransfer.id())))
+
+        // Update Info, since we modified data for this Library
+        val updateInfoResult = updateInfo(this.info()
+            ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id())))
+        return if (updateInfoResult.isFailure)
+            Result.failure((updateInfoResult.exceptionOrNull()
+                ?: Exception("Unknown failure updating LibraryInfo, libraryId: " + id())))
+        else
+            Result.success(transferredBook)
+    }
+
+    // Note: this retains the Checkout status of the User
+    suspend fun transferBookSourceLibraryToThisLibrary(bookToTransfer: Book): Result<Book> {
+        context.log.d(this, "Library (${id()}) - bookId ${bookToTransfer.id()}")
+        fetchInfoFailureReason()?.let { return Result.failure(Exception(it)) }
+
+        // Get the Book's Source Library
+        val fromSourceLibrary = bookToTransfer.sourceLibrary()
+
+        // Check `from` Source Library is same as this Library
+        if (fromSourceLibrary.id() == id())
+            return Result.failure(Exception("Book's Source Library is the same as this Library, bookId: " + bookToTransfer.id() + ", libraryId: " + id()))
+
+        // Check if `from` Source Library is known
+        if (fromSourceLibrary.fetchInfoFailureReason() != null)
+            return Result.failure(Exception("Book's fetched Source Library is not known, fromLibraryId: " + fromSourceLibrary.id() + ", bookId: " + bookToTransfer.id()))
+
+        // Check if Book is known at `from` Source Library
+        val fromSourceLibraryInfo = fromSourceLibrary.info()
+            ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + fromSourceLibrary.id()))
+        if (!fromSourceLibraryInfo.isKnownBook(bookToTransfer))
+            return Result.failure(Exception("Book is not known at from Source Library, bookId: " + bookToTransfer.id() + ", libraryId: " + fromSourceLibrary.id()))
+
+        ///////////////////////////////
+        //// Process Book Transfer ////
+        ///////////////////////////////
+
+        // • Remove Book from Library Inventory of Books at `from` Source Library
+        val removeBookResult =
+            fromSourceLibraryInfo.removeTransferringBookFromBooksAvailableMap(bookToTransfer)
+        if (removeBookResult.isFailure)
+            return Result.failure((removeBookResult.exceptionOrNull()
+                ?: Exception("Unknown failure removing Book from Library Inventory of Books, bookId: " + bookToTransfer.id() + ", libraryId: " + fromSourceLibrary.id())))
+
+        // Update `from` Source Library Info, bc data was modified for `from` Source Library
+        val updateFromSourceLibraryInfoResult = fromSourceLibrary.updateInfo(fromSourceLibraryInfo)
+        if (updateFromSourceLibraryInfoResult.isFailure) return Result.failure((updateFromSourceLibraryInfoResult.exceptionOrNull()
+            ?: Exception("Unknown failure updating LibraryInfo, libraryId: " + fromSourceLibrary.id() + ", bookId: " + bookToTransfer.id())))
+
+
+        // • Add Book to this Library's Inventory of Books
+        val addBookResult = this.info()?.addTransferringBookToBooksAvailableMap(bookToTransfer)
+            ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id()))
+        if (addBookResult.isFailure) return Result.failure((addBookResult.exceptionOrNull()
+            ?: Exception("Unknown failure adding Book to Library Inventory of Books, bookId: " + bookToTransfer.id() + ", libraryId: " + id())))
+
+
+        // • Transfer Book's Source Library to this Library
+        val transferredBookResult = bookToTransfer.updateSourceLibrary(this) // note: this only modifies the Book Role object, not the BookInfo.
+        if (transferredBookResult.isFailure) return Result.failure((transferredBookResult.exceptionOrNull()
+            ?: Exception("Unknown failure updating Book's Source Library, bookId: " + bookToTransfer.id())))
+
+        // Update Info, bc data was modified for this Library
+        val updateInfoResult2 = updateInfo(this.info()
+            ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id())))
+        return if (updateInfoResult2.isFailure)
+            Result.failure((updateInfoResult2.exceptionOrNull() ?: Exception("Unknown failure updating LibraryInfo, libraryId: " + id())))
+        else
+            transferredBookResult
+    }
+
+    /////////////////////////////////
+    // Published Helper Methods    //
+    /////////////////////////////////
+
+    // Note: This Library Role Object enforces the rule:
+    //   - if a User is not known, they are automatically registered in the system.
+    suspend fun isUnableToFindOrRegisterUser(user: User): Boolean {
+        context.log.d(this, "Library(${id()}) - userId ${user.id()}")
+        if (fetchInfoFailureReason() != null) return true
+        if (isKnownUser(user)) {
+            return false
+        }
+
+        // Automatically register a new User entry in the Library (if not already known)
+        // Note: todo - In a real system, this would be a separate step, and the User would have to confirm their registration.
+        val addRegisteredUserResult = this.info()?.registerUser(user.id()) ?: return true
+        if (addRegisteredUserResult.isFailure) return true
+
+        // Update Info, bc data was modified for this Library
+        val updateInfoResult = updateInfo(this.info() ?: return true)
+        return updateInfoResult.isFailure
+    }
+
+    suspend fun isKnownBook(book: Book): Boolean {
+        context.log.d(this, "Library(${id()}) - bookId ${book.id()}")
+        return if (fetchInfoFailureReason() != null)
+            false
+        else
+            this.info()?.isKnownBook(book)
+                ?: false
+    }
+
+    suspend fun isUnknownBook(book: Book): Boolean {
+        return !isKnownBook(book)
+    }
+
+    suspend fun isKnownUser(user: User): Boolean {
+        context.log.d(this, "Library(${id()}) - userId ${user.id()}")
+        return if (fetchInfoFailureReason() != null)
+            false
+        else
+            this.info()?.isKnownUser(user)
+                ?: false
+    }
+
+    suspend fun isBookAvailable(book: Book): Boolean {
+        context.log.d(this, "Library(${id()}) - bookId ${book.id()}")
+        return if (fetchInfoFailureReason() != null)
+            false
+        else
+            this.info()?.isBookAvailableToCheckout(book)
+                ?: false
+    }
+
+    suspend fun isBookCheckedOutByAnyUser(book: Book): Boolean {  // todo return SerializedResult<>?
+        context.log.d(this, "Library(${id()}) - bookId ${book.id()}")
+
+        return if (fetchInfoFailureReason() != null)
+            false
+        else
+            this.info()?.isBookIdCheckedOutByAnyUser(book.id())
+                ?: false
+    }
+
+    suspend fun findUserOfCheckedOutBook(book: Book): Result<User> {
+        context.log.d(this, "Library(${id()}) - bookId ${book.id()}")
+        fetchInfoFailureReason()?.let { return Result.failure(Exception(it)) }
+
+        // get the User's id from the Book checkout record
+        val userIdResult = this.info()?.findUserIdOfCheckedOutBook(book)
+            ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id()))
+        if (userIdResult.isFailure) return Result.failure((userIdResult.exceptionOrNull()
+            ?: Exception("Unknown failure finding User id of checked out Book, bookId: " + book.id())))
+
+        val userId = userIdResult.getOrNull()
+            ?: return Result.failure(Exception("User id is null, bookId: " + book.id()))
+
+        val fetchUserResult = User.fetchUser(userId, context)
+        if (fetchUserResult.isFailure) return Result.failure((fetchUserResult.exceptionOrNull()
+            ?: Exception("Unknown failure fetching User, userId: $userId")))
+
+        val user = fetchUserResult.getOrNull()
+            ?: return Result.failure(Exception("User is null, userId: $userId"))
+        return Result.success(user)
+    }
+
+    /////////////////////////////////////////
+    // Published Role Reporting Methods    //
+    /////////////////////////////////////////
+
+    suspend fun findBooksCheckedOutByUser(user: User): Result<ArrayList<Book>> {
+        context.log.d(this, "Library(${id()}) - userId ${user.id()}")
+        fetchInfoFailureReason()?.let { return Result.failure(Exception(it)) }
+
+        // Make sure User is Known
+        if (isUnableToFindOrRegisterUser(user)) {
+            return Result.failure(Exception("User is not known, userId: " + user.id()))
+        }
+        val entriesResult =
+            this.info()?.findAllCheckedOutBookIdsByUserId(user.id())
+                ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id()))
+        if (entriesResult.isFailure) {
+            return Result.failure((entriesResult.exceptionOrNull()
+                ?: Exception("Unknown failure finding checked out Book ids by User, userId: " + user.id())))
+        }
+
+        // Convert UUID2<Books to Books
+        val bookIds = (entriesResult.getOrNull()
+            ?: return Result.failure(Exception("Book ids is null, userId: " + user.id())))
+        val books = ArrayList<Book>()
+        for (entry in bookIds) {
+            books.add(Book(entry, this, context))
+        }
+        return Result.success(books)
+    }
+
+    suspend fun calculateAvailableBookIdToNumberAvailableList(): Result<Map<Book, Long>> {
+        context.log.d(this, "Library (" + id() + ")")
+        fetchInfoFailureReason()?.let { return Result.failure(Exception(it)) }
+
+        val entriesResult =
+            this.info()?.calculateAvailableBookIdToCountOfAvailableBooksMap()
+                ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id()))
+        if (entriesResult.isFailure) {
+            return Result.failure((entriesResult.exceptionOrNull()
+                ?: Exception("Unknown failure calculating available Book id to count of available Books map, libraryId: " + id())))
+        }
+
+        // Convert list of UUID2<Book> to list of Book
+        // Note: the BookInfo is not fetched, so the Book only contains the id. This is by design.
+        val bookIdToNumberAvailable =
+            (entriesResult.getOrNull()
+                ?: return Result.failure(Exception("Book id to count of available Books map is null, libraryId: " + id())))
+        val bookToNumberAvailable= mutableMapOf<Book, Long>()
+        for ((key, value) in bookIdToNumberAvailable) {
+            bookToNumberAvailable[Book(key, this, context)] = value
+        }
+        return Result.success(bookToNumberAvailable.toImmutableMap())
+    }
+
+    /////////////////////////////////////////
+    // Published Testing Helper Methods    //
+    /////////////////////////////////////////
+
+    // Intention revealing method name
+    suspend fun addTestBookToLibrary(book: Book, count: Int): Result<Book> {
+        context.log.d(this, "Library (" + id() + ") book: " + book + ", count: " + count)
+        return addBookToLibrary(book, count)
+    }
+
+    suspend fun addBookToLibrary(book: Book, count: Int): Result<Book> {
+        context.log.d(this, "Library (" + id() + ") book: " + book + ", count: " + count)
+        fetchInfoFailureReason()?.let { return Result.failure(Exception(it)) }
+
+        val addBookResult = this.info()?.addTestBook(book.id(), count)
+            ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id()))
+        if (addBookResult.isFailure) return Result.failure((addBookResult.exceptionOrNull()
+            ?: Exception("Unknown failure adding Book to Library, bookId: " + book.id())))
+
+        // Update the Info
+        val updateInfoResult = updateInfo(this.info()
+            ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id())))
+        return if (updateInfoResult.isFailure)
+            Result.failure((updateInfoResult.exceptionOrNull()
+                ?: Exception("Unknown failure updating LibraryInfo, libraryId: " + id())))
+        else
+            Result.success(book)
+    }
+
+    fun dumpDB(context: Context) {
+        context.log.d(this, "Dumping Library DB:")
+        context.log.d(this, this.toJson())
+        println()
+    }
+
+    suspend fun transferBookAndCheckOutFromUserToUser(book: Book, fromUser: User, toUser: User): Result<Book> {
+        context.log.d(this, "Library (" + id() + ") book: " + book + ", fromUser: " + fromUser + ", toUser: " + toUser)
+        fetchInfoFailureReason()?.let { return Result.failure(Exception(it)) }
+
+        val transferResult = this.info()?.transferCheckedOutBookFromUserToUser(book, fromUser, toUser)
+            ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id()))
+        if (transferResult.isFailure) return Result.failure((transferResult.exceptionOrNull()
+            ?: Exception("Unknown failure transferring Book from User to User, bookId: " + book.id())))
+
+        // Update the Info
+        val updateInfoResult = updateInfo(this.info()
+            ?: return Result.failure(Exception("LibraryInfo is null, libraryId: " + id())))
+        return if (updateInfoResult.isFailure)
+            Result.failure((updateInfoResult.exceptionOrNull()
+                ?: Exception("Unknown failure updating LibraryInfo, libraryId: " + id())))
+        else
+            Result.success(book)
+    }
+
+    companion object {
+
+        /////////////////////////
+        // Static constructors //
+        /////////////////////////
+
+        suspend fun fetchLibrary(
+            uuid2: UUID2<Library>,
+            context: Context
+        ): Result<Library> {
+            val repo = context.libraryInfoRepo
+            val fetchInfoResult = repo.fetchLibraryInfo(uuid2)
+            if (fetchInfoResult.isFailure) return Result.failure((fetchInfoResult.exceptionOrNull()
+                    ?: Exception("Unknown failure fetching LibraryInfo, libraryId: $uuid2")))
+
+
+            val info = (fetchInfoResult.getOrNull()
+                ?: return Result.failure(Exception("LibraryInfo is null, libraryId: $uuid2")))
+
+            return Result.success(Library(info, context))
+        }
+    }
+}
+
+// for kotlinx.serialization
+object LibrarySerializer : KSerializer<Library> {
+    override val descriptor = PrimitiveSerialDescriptor("Library", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Library {
+        libraryAppContext.log.e(this,"WARNING: LibrarySerializer.deserialize() called - DO NOT USE IN PRODUCTION." +
+                "Should only be used for debugging/testing. Use the Library constructor instead.")
+
+        @Suppress("UNCHECKED_CAST")
+        return Library(UUID2Result.serializer().deserialize(decoder).uuid2 as UUID2<Library>,
+            libraryAppContext
+        )
+    }
+
+    override fun serialize(encoder: Encoder, value: Library) {
+        encoder.encodeSerializableValue( // unlike `encodeString`, this will NOT add quotes around the string
+            UUID2Result.serializer(),
+            UUID2Result(value.id())
+        )
+    }
+}

--- a/kotlin/ktor-web-app-server_Log.kt
+++ b/kotlin/ktor-web-app-server_Log.kt
@@ -1,0 +1,95 @@
+package common.log
+
+/**
+ * Log Role
+ *
+ * Logs to the system console
+ *
+ * @author Chris Athanas (realityexpanderdev@gmail.com)
+ * @since 0.12 Kotlin conversion
+ */
+
+open class Log : ILog {
+    // These could be swapped out for files or network calls.
+    private fun debug(tag: String, msg: String) {
+        println("$tag: $msg")
+    }
+
+    private fun warning(tag: String, msg: String) {
+        System.err.println("$tag:(WARNING) $msg")
+    }
+
+    private fun error(tag: String, msg: String) {
+        System.err.println("$tag:(ERROR) $msg")
+    }
+
+    // example: log.d(this, "message") will print "ClassName➤MethodName(): message"
+    override fun d(tag: Any?, msg: String) {
+        if (tag == null) {
+            debug("null", msg)
+            return
+        }
+        if (tag is String) {
+            debug(tag, msg)
+            return
+        }
+        debug(calcLogLabel(tag), msg)
+    }
+
+    override fun e(tag: Any?, msg: String, e: Exception) {
+        if (tag == null) {
+            error("null", msg)
+            return
+        }
+        if (tag is String) {
+            error(tag, msg)
+            return
+        }
+
+        // Collect stacktrace to a comma delimited string
+        val stacktrace = StringBuilder()
+        for (ste in e.stackTrace) {
+            stacktrace.append(ste.toString()).append(", ")
+        }
+        error(calcLogLabel(tag), "$msg, $stacktrace")
+        e.printStackTrace() // LEAVE for debugging
+    }
+
+    // example: log.w(this, "message") will print "ClassName➤MethodName():(WARNING) message"
+    override fun w(tag: Any?, msg: String) {
+        if (tag == null) {
+            warning("null", msg)
+            return
+        }
+        if (tag is String) {
+            warning(tag, msg)
+            return
+        }
+        warning(calcLogLabel(tag), msg)
+    }
+
+    // example: log.e(this, "message") will print "ClassName➤MethodName():(ERROR) message"
+    override fun e(tag: Any?, msg: String) {
+        if (tag == null) {
+            error("null", msg)
+            return
+        }
+        if (tag is String) {
+            error(tag, msg)
+            return
+        }
+        error(calcLogLabel(tag), msg)
+    }
+
+    protected open fun calcLogLabel(obj: Any): String {
+        return calcSimpleName(obj) + "➤" + calcMethodName() + "()"
+    }
+
+    protected open fun calcMethodName(): String {
+        return Thread.currentThread().stackTrace[4].methodName
+    }
+
+    protected open fun calcSimpleName(obj: Any): String {
+        return obj.javaClass.simpleName
+    }
+}

--- a/kotlin/ktor-web-app-server_PrivateLibrary.kt
+++ b/kotlin/ktor-web-app-server_PrivateLibrary.kt
@@ -1,0 +1,179 @@
+package domain.library
+
+import common.uuid2.IUUID2
+import common.uuid2.UUID2
+import domain.Context
+import domain.book.Book
+import domain.library.data.LibraryInfo
+import domain.user.User
+
+/**
+ *
+ * Private Library
+ * 
+ * A Private Library is not a system Library, so it doesn't access the Account Role Object for any account checks.
+ * 
+ * Used to represent a "Personal" Library, or a library for a single "found" book, or a Library for a newly created
+ * book, etc.
+ *
+ *
+ *  * A **`PrivateLibrary`** is a **`Library`** that is not part of
+ *    any system **`Library`**.
+ *  * Any **`User`** can **`checkIn()`** and **`checkOut()`** any **`Book`**
+ *    from this **`PrivateLibrary`**.
+ *  * Users can have unlimited Private Libraries & unlimited number of Books in them.
+ *  * A **`PrivateLibrary`** is identical to a normal **`Library`**, except it doesn't verify any
+ *    **`Account`** info and any **`User`** can **`checkIn`** and
+ *    **`checkOut`** any **`Book`**.
+ *  * _Note: A special case **`PrivateLibrary`** is an Orphan ****`PrivateLibrary` which
+ *    only allows a single Book of a specific id to be checked into/out of it. See below._
+ *
+ * 
+ * BOOP design notes for this **`PrivateLibrary`** class:
+ * 
+ * This is a system design **alternative** to:
+ *
+ *  * ... using null to represent a Book which is not part of any Library.
+ *  * ... naming this class "NoLibrary" or "PersonalLibrary" or "UnassignedLibrary"
+ *  * ... to using "null" we create an object that conveys the intention behind what "null" means in this context.
+ *  * Question: What is the concept of a "null" Library? Maybe it is a Library which is not part of any system Library?
+ *  * How about a "Library" which is not part of any system Library is called a "PrivateLibrary"?
+ *
+ * ORPHAN Private Libraries:
+ *
+ *  * Orphan definition: *An orphan is a child that has no parent.*<br></br>
+ *  * For a Book, it would have no "source" Public Library.
+ *  * If a Private Library is created from a BookId, it is called an ORPHAN Private Library
+ *    and its sole duty is to hold ONLY 1 Book of one specific BookId, and never any other BookIds.
+ *  * It can only ever hold 1 Book at a time.
+ *  * ORPHAN PrivateLibraries have the **`isForOnlyOneBook`** flag set to true.
+ *  * Note: I could have subclassed **`PrivateLibrary`** into **`OrphanPrivateLibrary`**,
+ *    but that would have added a deeper inheritance tree & complexity to the system for a simple edge use case.
+ *
+ */
+
+class PrivateLibrary : Library, IUUID2 {
+    // true = ORPHAN Private Library, false = normal Private Library
+    private val isForOnlyOneBook: Boolean
+
+    // Note: the naming here conveys the intent of the variable,
+    //       even if the reader doesn't know about "Orphan" libraries.
+    constructor(
+        info: LibraryInfo,
+        context: Context
+    ) : super(info, context) {
+        id()._setUUID2TypeStr(UUID2.calcUUID2TypeStr(PrivateLibrary::class.java))
+        isForOnlyOneBook = false
+    }
+    constructor(
+        id: UUID2<Library>,
+        context: Context
+    ) : super(id, context) {
+        id()._setUUID2TypeStr(UUID2.calcUUID2TypeStr(PrivateLibrary::class.java))
+        isForOnlyOneBook = false
+    }
+    constructor(
+        bookId: UUID2<Book>,
+        @Suppress("UNUSED_PARAMETER")
+        isForOnlyOneBook: Boolean,  // note: always `true` for this constructor.
+        context: Context
+    ) : super(UUID2(bookId.uuid(), Library::class.java), context) // make the LibraryId match the BookId
+    {
+        // Note: This creates an ORPHAN private library.
+        // It is an ORPHAN bc it is NOT associated with any other system Library (private or not).
+        id()._setUUID2TypeStr(UUID2.calcUUID2TypeStr(PrivateLibrary::class.java))
+
+        // It is an ORPHAN bc it is NOT associated with any other system Library (private or not).
+        // ORPHAN Private Library can:
+        //  - Contain only 1 Book,
+        //  - And the 1 BookId must always match initial BookId that created this Orphan Library.
+        this.isForOnlyOneBook = true
+    }
+    constructor(
+        context: Context
+    ) : this(UUID2.randomUUID2<Book>(), true,  context) {
+        // Note: this creates an ORPHAN private library with a random id.
+        context.log.w(this, "PrivateLibrary (" + id() + ") created with ORPHAN Library with Random Id.")
+    }
+
+    //////////////////////////////////////////////////
+    // PrivateLibrary Domain Business Logic Methods //
+    //////////////////////////////////////////////////
+
+    override suspend fun checkOutBookToUser(book: Book, user: User): Result<Book> {
+        context.log.d(this, "checkOutBookToUser() called, bookId: " + book.id() + ", userId: " + user.id())
+        fetchInfoFailureReason()?.let { return Result.failure(Exception(it)) }
+
+        val libraryInfo = super.info() ?: return Result.failure(Exception("Failed to get LibraryInfo, bookId: " + book.id()))
+
+        // Automatically upsert the User into the Library's User Register
+        // - Private libraries are open to all users, so we don't need to check if the user is registered.
+        val addRegisteredUserResult = libraryInfo.registerUser(user.id())
+        if (addRegisteredUserResult.isFailure) return Result.failure(Exception("Failed to register User in Library, userId: " + user.id()))
+
+        if (!isForOnlyOneBook) {
+            // note: PrivateLibraries bypass all normal Library User Account checks
+            return libraryInfo.checkOutPrivateLibraryBookToUser(book, user)
+        }
+
+        // Orphan Libraries can only check out 1 Book to 1 User.
+        if (libraryInfo.findAllKnownBookIds().size != 1)
+            return Result.failure(Exception("Orphan Private Library can only check-out 1 Book to Users, bookId: " + book.id()))
+
+        // Only allow check out if the Book Id matches the initial Book Id that created this Orphan Library.
+        val bookIds = libraryInfo.findAllKnownBookIds()
+        val firstBookId = bookIds.toTypedArray()[0] // there should only be 1 bookId
+        if (firstBookId != book.id()) return Result.failure(Exception("Orphan Private Library can only check-out 1 Book to Users and must be the same Id as the initial Book placed in the PrivateLibrary, bookId: " + book.id()))
+
+        val checkOutResult = libraryInfo.checkOutPrivateLibraryBookToUser(book, user) // note: we bypass all normal Library User Account checking
+        if (checkOutResult.isFailure) return Result.failure(checkOutResult.exceptionOrNull()
+                ?: Exception("Failed to check-out Book from Library, bookId: " + book.id()))
+
+        // Update the Info
+        val updateInfoResult: Result<LibraryInfo> = updateInfo(libraryInfo)
+        return if (updateInfoResult.isFailure)
+            Result.failure(updateInfoResult.exceptionOrNull() ?: Exception("Failed to update LibraryInfo, bookId: " + book.id()))
+        else
+            checkOutResult
+    }
+
+    override suspend fun checkInBookFromUser(book: Book, user: User): Result<Book> {
+        context.log.d(this, "checkInBookFromUser() called, bookId: " + book.id() + ", userId: " + user.id())
+        fetchInfoFailureReason()?.let { return Result.failure(Exception(it)) }
+
+        if (!isForOnlyOneBook) {
+            // note: we bypass all normal Library User Account checking
+            return super.info()?.checkInPrivateLibraryBookFromUser(book, user) 
+                ?: Result.failure(Exception("Failed to check-in Book from Library, bookId: " + book.id()))
+        }
+
+        // Orphan Libraries can only check in 1 Book from Users.
+        info()?.findAllKnownBookIds()?.size?.let {
+            if (it != 1) return Result.failure(Exception("Orphan Private Library can only check-in 1 Book from Users, bookId: " + book.id()))
+        }
+
+        // Only allow checkIn if the BookId matches the initial BookId that created this Orphan PrivateLibrary.
+        info()?.let { libraryInfo ->
+            val bookIds: Set<UUID2<Book>> = libraryInfo.findAllKnownBookIds()
+            val firstBookId: UUID2<Book> = bookIds.toTypedArray()[0] // there should only be 1 BookId
+            
+            if (firstBookId != book.id())
+                return Result.failure(Exception("Orphan Private Library can only check-in 1 Book from Users and must be the same Id as the initial Book placed in the PrivateLibrary, bookId: " + book.id()))
+        } ?: return Result.failure(Exception("Failed to check-in Book from Private Library, bookId: " + book.id()))
+
+        // note: we bypass all normal Library User Account checking
+        val checkInResult = super.info()?.checkInPrivateLibraryBookFromUser(book, user)
+            ?: Result.failure(Exception("Failed to check-in Book from PrivateLibrary, bookId: " + book.id() + ", userId: " + user.id()))
+        if (checkInResult.isFailure) 
+            return Result.failure(Exception("Failed to check-in Book from Private Library, bookId: " + book.id()))
+
+        // Update the Info
+        val updateInfoResult = updateInfo(info()
+            ?: return Result.failure(Exception("Failed to update LibraryInfo, bookId: " + book.id())))
+        return if (updateInfoResult.isFailure)
+            Result.failure(updateInfoResult.exceptionOrNull()
+                ?: Exception("Failed to update LibraryInfo, bookId: " + book.id()))
+        else
+            checkInResult
+    }
+}

--- a/kotlin/ktor-web-app-server_SubModule2.kt
+++ b/kotlin/ktor-web-app-server_SubModule2.kt
@@ -1,0 +1,24 @@
+package org.example
+
+import net.iharder.Base64
+
+object SubModule2 {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        System.out.printf("Hello and welcome!")
+
+        for (i in 1..5) {
+
+            println("i = $i")
+        }
+    }
+
+    fun output(value: String)  {
+        println("Value from subclass 2: $value")
+
+        val z = "hello"
+        val result = Base64.encodeObject(z)
+
+        println("result: $result")
+    }
+}

--- a/kotlin/ktor-web-app-server_TestingUtils.kt
+++ b/kotlin/ktor-web-app-server_TestingUtils.kt
@@ -1,0 +1,233 @@
+package util.testingUtils
+
+import common.uuid2.UUID2
+import domain.Context
+import domain.account.Account
+import domain.account.data.AccountInfo
+import domain.book.Book
+import domain.book.data.BookInfo
+import domain.book.data.local.BookInfoEntity
+import domain.book.data.network.BookInfoDTO
+import domain.library.Library
+import domain.library.data.LibraryInfo
+import domain.user.User
+import domain.user.data.UserInfo
+import java.time.Instant
+import java.util.*
+
+/**
+ * Testing Utility Methods
+ *
+ * Useful for adding fake data to the Repos, DB and API for testing purposes.
+ *
+ * @author Chris Athanas (realityexpanderdev@gmail.com)
+ * @since 0.12 Kotlin conversion
+ */
+
+class TestingUtils(val context: Context) {
+
+    companion object {
+        fun createTempFileName(prefix: String) = "test-$prefix-${UUID.randomUUID()}.json"
+        fun createTempName(prefix: String) = "test-$prefix-${UUID.randomUUID()}"
+    }
+
+    ///////////////////////////
+    // Book Repo, DB and API //
+    ///////////////////////////
+
+    suspend fun populateFakeBooksInBookInfoRepoDBandAPI() {
+        populateDBWithFakeBookInfo()
+        populateApiWithFakeBookInfo()
+    }
+
+    suspend fun populateDBWithFakeBookInfo() {
+        for (i in 0..10) {
+            val id = 1000 + i * 100
+            val result: Result<BookInfo> = context.bookInfoRepo
+                .upsertTestEntityBookInfoToDB(
+                    BookInfoEntity(
+                        UUID2.createFakeUUID2<Book>(id),
+                        "Title $id",
+                        "Author $id",
+                        "Description $id",
+                        "Some extra info from the Entity$id",
+                        Instant.parse("2023-01-01T00:00:00.00Z").toEpochMilli(),
+                        Instant.parse("2023-01-01T00:00:00.00Z").toEpochMilli(),
+                        false
+                    )
+                )
+            if (result.isFailure) {
+                context.log.d(this, "Error: " + result.exceptionOrNull()?.message)
+            }
+        }
+    }
+
+    suspend fun populateApiWithFakeBookInfo() {
+        for (i in 0..10) {
+            val id = 1000 + i * 100
+            val result: Result<BookInfo> = context.bookInfoRepo.upsertTestDTOBookInfoToApi(
+                BookInfoDTO(
+                    UUID2.createFakeUUID2<Book>(id),
+                    "Title $id",
+                    "Author $id",
+                    "Description $id",
+                    "Some extra info from the DTO$id",
+                    Instant.parse("2023-01-01T00:00:00.00Z").toEpochMilli(),
+                    Instant.parse("2023-01-01T00:00:00.00Z").toEpochMilli(),
+                    false
+                )
+            )
+            if (result.isFailure) {
+                context.log.d(this, "Error: " + result.exceptionOrNull()?.message)
+            }
+        }
+    }
+
+    suspend fun printBookInfoDBandAPIEntries() {
+        print("\n")
+        context.log.d(this, "DB Dump")
+        context.bookInfoRepo.printDB(context.log)
+        print("\n")
+        context.log.d(this, "API Dump")
+        context.bookInfoRepo.printAPI(context.log)
+        print("\n")
+    }
+
+    suspend fun addFakeBookInfoToBookInfoRepo(id: Int?): Result<BookInfo> {
+        val bookInfo: BookInfo = createFakeBookInfo(id)
+        return context.bookInfoRepo.upsertBookInfo(bookInfo)
+    }
+
+    fun createFakeBookInfo(id: Int?): BookInfo {
+        var fakeId = id
+        if (fakeId == null) fakeId = 1
+        val uuid2: UUID2<Book> = UUID2.createFakeUUID2<Book>(fakeId)
+        
+        return BookInfo(
+            uuid2,
+            "Book $fakeId",
+            "Author $fakeId",
+            "Description $fakeId",
+            Instant.parse("2023-01-01T00:00:00.00Z").toEpochMilli(),
+            Instant.parse("2023-01-01T00:00:00.00Z").toEpochMilli(),
+            false
+        )
+    }
+
+    ////////////////
+    // User Repo  //
+    ////////////////
+
+    suspend fun createFakeUserInfoInUserInfoRepo(id: Int?): Result<UserInfo> {
+        var someNumber = id
+        if (someNumber == null) someNumber = 1
+
+        val upsertUserInfoResult: Result<UserInfo> = context.userInfoRepo
+            .upsertUserInfo(
+                UserInfo(
+                    UUID2.createFakeUUID2<User>(someNumber),  // uses Domain id
+                    "User $someNumber",
+                    "user$someNumber@gmail.com"
+                )
+            )
+        if (upsertUserInfoResult.isFailure) {
+            context.log.d(
+                this,
+                "User Error: " + upsertUserInfoResult.exceptionOrNull()?.message
+            )
+        }
+
+        return upsertUserInfoResult
+    }
+
+    ///////////////////
+    // Account Repo  //
+    ///////////////////
+
+    suspend fun createFakeAccountInfoInAccountRepo(id: Int?): Result<AccountInfo> {
+        var someNumber = id
+        if (someNumber == null) someNumber = 1
+
+        val accountInfoResult: Result<AccountInfo> = context.accountInfoRepo
+            .upsertAccountInfo(
+                AccountInfo(
+                    UUID2.createFakeUUID2<Account>(someNumber),  // uses Domain id
+                    "Account for User $someNumber"
+                )
+            )
+        if (accountInfoResult.isFailure) {
+            context.log.d(this, "Account Error: " + accountInfoResult.exceptionOrNull()?.message)
+            return accountInfoResult
+        }
+
+        val accountInfo: AccountInfo = (accountInfoResult.getOrNull()
+            ?: return Result.failure(Exception("AccountInfo was null.")))
+        accountInfo.addTestAuditLogMessage("AccountInfo created for User $someNumber")
+
+        return accountInfoResult
+    }
+
+    suspend fun populateAccountWithFakeAuditMessages(
+        accountId: UUID2<Account>,
+        numberOfMessagesToCreate: Int
+    ) {
+        context.log.d(this, "accountId: $accountId, numberOfAccountsToCreate: $numberOfMessagesToCreate")
+        val infoResult: Result<AccountInfo> = context.accountInfoRepo.fetchAccountInfo(accountId)
+        if (infoResult.isFailure) {
+            context.log.d(this, "Error: " + infoResult.exceptionOrNull()?.message)
+            return
+        }
+
+        val accountInfo: AccountInfo = (infoResult.getOrNull() ?: return)
+        for (i in 0 until numberOfMessagesToCreate) {
+            accountInfo.addTestAuditLogMessage(
+                "Test Audit message " + i + " for account: " + accountInfo.id()
+            )
+        }
+    }
+
+    ///////////////////
+    // Library Repo  //
+    ///////////////////
+
+    suspend fun createFakeLibraryInfoInLibraryInfoRepo(id: Int?): Result<LibraryInfo> {
+        var someNumber = id
+        if (someNumber == null) someNumber = 1
+
+        return context.libraryInfoRepo
+            .upsertLibraryInfo(
+                LibraryInfo(
+                    UUID2.createFakeUUID2<Library>(someNumber),  // uses DOMAIN id
+                    "Library $someNumber"
+                )
+            )
+    }
+
+    suspend fun populateLibraryWithFakeBooks(
+        libraryId: UUID2<Library>,
+        numberOfBooksToCreate: Int
+    ) {
+        context.log.d(this, "libraryId: $libraryId, numberOfBooksToCreate: $numberOfBooksToCreate")
+        val libraryInfoResult: Result<LibraryInfo> = context.libraryInfoRepo.fetchLibraryInfo(libraryId)
+        if (libraryInfoResult.isFailure) {
+            context.log.d(this, "Error: " + libraryInfoResult.exceptionOrNull()?.message)
+            return
+        }
+
+        val libraryInfo: LibraryInfo = libraryInfoResult.getOrNull() ?: return
+
+        for (i in 0 until numberOfBooksToCreate) {
+            val addBookResult: Result<UUID2<Book>> =
+                libraryInfo.addTestBook(UUID2.createFakeUUID2<Book>(1000 + i * 100), 1)
+            if (addBookResult.isFailure) {
+                context.log.e(this, "Error: " + addBookResult.exceptionOrNull()?.message)
+            }
+        }
+
+        // Update the Library with the new Info // todo still needed?
+        val updateLibraryResult: Result<LibraryInfo> = context.libraryInfoRepo.upsertLibraryInfo(libraryInfo)
+        if (updateLibraryResult.isFailure) {
+            context.log.e(this, "Error: " + updateLibraryResult.exceptionOrNull()?.message)
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `Library` and `PrivateLibrary` domain roles with checkout/transfer logic, add `Log` implementation, testing utilities, and a small sample module.
> 
> - **Domain**:
>   - **`domain.library.Library`**: Implements fetch/update against `ILibraryInfoRepo`; checkout/checkin; book/user validation; inter-library transfers; reporting helpers; `kotlinx.serialization` support.
>   - **`domain.library.PrivateLibrary`**: Extends `Library` to bypass account checks; supports ORPHAN mode restricting to a single `Book` id.
> - **Utilities**:
>   - **`util.testingUtils.TestingUtils`**: Helpers to populate DB/API repos with fake `BookInfo`, `UserInfo`, `AccountInfo`, `LibraryInfo`; print dumps and seed audit logs.
> - **Logging**:
>   - **`common.log.Log`**: Console logger implementing `ILog` with debug/warn/error, auto tag generation.
> - **Sample**:
>   - **`org.example.SubModule2`**: Simple example with Base64 usage and console output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fd827f6945ed5f87f290f00900c60cdc0943f20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added Library and PrivateLibrary entities with checkout/check-in, transfers, availability checks, and user/book queries; includes serialization and a factory loader.
  * Introduced console logging utility with debug, warning, and error levels.
  * Added SubModule2 example with a simple CLI and Base64 encoding demo.
* Tests
  * Added TestingUtils to seed fake data across books, users, accounts, and libraries; populate storage/API; and print diagnostics for quick setup and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->