### PR TITLE
Add SCALA vulnerable samples batch 1/1

### DIFF
--- a/scala/sast-rules_scala_xml_test-SAMLIgnoreComments.scala
+++ b/scala/sast-rules_scala_xml_test-SAMLIgnoreComments.scala
@@ -1,0 +1,21 @@
+// License: LGPL-3.0 License (c) find-sec-bugs
+package xml
+
+import org.opensaml.xml.parse.BasicParserPool
+import org.opensaml.xml.parse.ParserPool
+import org.springframework.context.annotation.Bean
+
+
+class SAMLIgnoreComments {
+  @Bean private[xml] def parserPool = {
+    val pool = new BasicParserPool
+    pool.setIgnoreComments(false)
+    pool
+  }
+
+  @Bean private[xml] def parserPool2(): Unit = {
+    val shouldIgnore = false
+    val pool = new BasicParserPool
+    pool.setIgnoreComments(shouldIgnore)
+  }
+}

--- a/scala/sast-rules_scala_xss_test-WicketXSS.scala
+++ b/scala/sast-rules_scala_xss_test-WicketXSS.scala
@@ -1,0 +1,13 @@
+// License: LGPL-3.0 License (c) find-sec-bugs
+package xss
+
+import org.apache.wicket.markup.html.WebPage
+import org.apache.wicket.markup.html.basic.Label
+import org.apache.wicket.request.mapper.parameter.PageParameters
+
+class WicketXSS extends WebPage {
+  def XssWicketExamplePage(pageParameters: PageParameters): Unit = {
+    add(new Label("test").setEscapeModelStrings(false))
+  }
+}
+

--- a/scala/sast-rules_scala_xss_test-XSSReqParamToServletWriter.scala
+++ b/scala/sast-rules_scala_xss_test-XSSReqParamToServletWriter.scala
@@ -1,0 +1,70 @@
+// License: LGPL-3.0 License (c) find-sec-bugs
+// scaffold: dependencies=org.owasp.encoder.encoder@1.2.3
+package xss
+
+import org.owasp.encoder.Encode
+import javax.servlet.ServletException
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import java.io.IOException
+import java.io.PrintWriter
+import java.util
+
+// Also contains vulnerabilities found under ids: XSS_SERVLET,SERVLET_PARAMETER
+class XSSReqParamToServletWriter extends HttpServlet {
+  @throws[ServletException]
+  @throws[IOException]
+  protected def danger(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
+    val input1 = req.getParameter("input1")
+    resp.getWriter.write(input1) // BAD
+
+  }
+
+  @throws[ServletException]
+  @throws[IOException]
+  override protected def doGet(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
+    val input1 = req.getParameter("input1") // BAD
+    val sessionId = req.getRequestedSessionId
+    val queryString = req.getQueryString
+    val referrer = req.getHeader("Referer") //Should have a higher priority
+    if (referrer != null && referrer.startsWith("http://company.ca")) { // Header access
+      val host = req.getHeader("Host")
+      val referer = req.getHeader("Referer")
+      val userAgent = req.getHeader("User-Agent")
+    }
+    val writer = resp.getWriter
+    writer.write(input1)
+  }
+
+  @throws[ServletException]
+  @throws[IOException]
+  protected def danger3(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
+    val input1 = req.getParameter("input1")
+    val map = req.getParameterMap
+    val vals = req.getParameterValues("input2")
+    val names = req.getParameterNames
+    val contentType = req.getContentType
+    val serverName = req.getServerName
+    resp.getWriter.write(input1)
+  }
+
+  @throws[ServletException]
+  @throws[IOException]
+  protected def ok(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
+    val input1 = req.getParameter("input1")
+    val writer = resp.getWriter
+    writer.write(Encode.forHtml(input1)) // OK
+  }
+
+  @throws[ServletException]
+  @throws[IOException]
+  protected def ok2(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
+    val input1 = req.getParameter("input1")
+    val writer = resp.getWriter
+    writer.write(Encode.forHtml(input1))
+  }
+}
+

--- a/scala/sast-rules_scala_xxe_test-XMLRdr.scala
+++ b/scala/sast-rules_scala_xxe_test-XMLRdr.scala
@@ -1,0 +1,33 @@
+// License: LGPL-3.0 License (c) find-sec-bugs
+package xxe
+
+import org.xml.sax.InputSource
+import org.xml.sax.SAXException
+import org.xml.sax.XMLReader
+import org.xml.sax.helpers.DefaultHandler
+import org.xml.sax.helpers.XMLReaderFactory
+import javax.xml.parsers.ParserConfigurationException
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+
+
+object XMLRdr {
+  @throws[ParserConfigurationException]
+  @throws[SAXException]
+  @throws[IOException]
+  private def receiveXMLStream(inStream: InputStream, defHandler: DefaultHandler): Unit = { // ...
+    val reader = XMLReaderFactory.createXMLReader
+    reader.parse(new InputSource(inStream))
+  }
+
+  @throws[ParserConfigurationException]
+  @throws[SAXException]
+  @throws[IOException]
+  def main(args: Array[String]): Unit = {
+    val xmlString = "<?xml version=\"1.0\"?>" + "<!DOCTYPE test [ <!ENTITY foo SYSTEM \"C:/Code/public.txt\"> ]><test>&foo;</test>" // Tainted input
+    val is = new ByteArrayInputStream(xmlString.getBytes)
+    receiveXMLStream(is, new DefaultHandler)
+  }
+}
+

--- a/scala/sast-rules_scala_xxe_test-XPathXXE.scala
+++ b/scala/sast-rules_scala_xxe_test-XPathXXE.scala
@@ -1,0 +1,70 @@
+// License: LGPL-3.0 License (c) find-sec-bugs
+package xxe
+
+import org.xml.sax.InputSource
+import javax.xml.XMLConstants
+import javax.xml.parsers.DocumentBuilder
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.xpath.XPath
+import javax.xml.xpath.XPathExpression
+import javax.xml.xpath.XPathFactory
+
+
+object XPathXXE {
+  @throws[Exception]
+  def main(args: Array[String]): Unit = {
+    safe(args(0))
+    unsafe1(args(0))
+    unsafe2(args(0))
+    unsafe3(args(0))
+  }
+
+  @throws[Exception]
+  def safe(str: String): Unit = {
+    val df = DocumentBuilderFactory.newInstance
+    df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+    df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+    df.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+    df.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+
+    val builder = df.newDocumentBuilder
+    val xPathFactory = XPathFactory.newInstance
+    val xpath = xPathFactory.newXPath
+    val xPathExpr = xpath.compile("/xmlhell/text()")
+    val result = xPathExpr.evaluate(builder.parse(str))
+  }
+
+  @throws[Exception]
+  def unsafe1(str: String): Unit = {
+    val df = DocumentBuilderFactory.newInstance
+    df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+    df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+    val builder = df.newDocumentBuilder
+    val xPathFactory = XPathFactory.newInstance
+    val xpath = xPathFactory.newXPath
+    val xPathExpr = xpath.compile("/xmlhell/text()")
+    val result = xPathExpr.evaluate(builder.parse(str))
+  }
+
+  @throws[Exception]
+  def unsafe2(str: String): Unit = {
+    val df = DocumentBuilderFactory.newInstance
+    //df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    //df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    val builder = df.newDocumentBuilder
+    val xPathFactory = XPathFactory.newInstance
+    val xpath = xPathFactory.newXPath
+    val xPathExpr = xpath.compile("/xmlhell/text()")
+    val result = xPathExpr.evaluate(new InputSource(str))
+  }
+
+  @throws[Exception]
+  def unsafe3(str: String): Unit = {
+    val df = DocumentBuilderFactory.newInstance
+    val builder = df.newDocumentBuilder
+    val xPathFactory = XPathFactory.newInstance
+    val xpath = xPathFactory.newXPath
+    val xPathExpr = xpath.compile("/xmlhell/text()")
+    xPathExpr.evaluate(new InputSource(str), null)
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Scala test samples demonstrating XSS (Wicket/Servlet), XXE (XMLReader/XPath), and SAML parser comment handling.
> 
> - **Security Test Samples (Scala)**:
>   - **XSS**:
>     - `xss/WicketXSS.scala`: Wicket page with `Label.setEscapeModelStrings(false)`.
>     - `xss/XSSReqParamToServletWriter.scala`: Servlet writing request params to response; includes safe variants using `Encode.forHtml`.
>   - **XXE**:
>     - `xxe/XMLRdr.scala`: SAX `XMLReader` parsing untrusted input enabling external entity resolution.
>     - `xxe/XPathXXE.scala`: XPath evaluation with `DocumentBuilderFactory`; includes both secure config and multiple unsafe variants.
>   - **XML/SAML Parser Config**:
>     - `xml/SAMLIgnoreComments.scala`: `BasicParserPool` with `setIgnoreComments(false)` and via variable flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e110e930905dfc57fbaddb60070d0b768a2ee8de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added scenarios for SAML XML parsing to validate handling of XML comments.
  - Introduced XSS test cases for web pages and servlets, covering both vulnerable and safely encoded outputs.
  - Added XXE test coverage using SAX and XPath, including secure and insecure configurations to validate protections.
  - Included examples demonstrating secure processing flags and external entity restrictions for XML parsers.
  - Expanded test suite to improve detection of common web security issues (XSS, XXE) across multiple patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->