### PR TITLE
Add PHP vulnerable samples batch 1/2

### DIFF
--- a/php/MySQL.php
+++ b/php/MySQL.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+
+This file contains all of the code to setup the initial MySQL database. (setup.php)
+
+*/
+
+if( !defined( 'DVWA_WEB_PAGE_TO_ROOT' ) ) {
+	define( 'DVWA_WEB_PAGE_TO_ROOT', '../../../' );
+}
+
+if( !@($GLOBALS["___mysqli_ston"] = mysqli_connect( $_DVWA[ 'db_server' ],  $_DVWA[ 'db_user' ],  $_DVWA[ 'db_password' ], "", $_DVWA[ 'db_port' ] )) ) {
+	dvwaMessagePush( "Could not connect to the database service.<br />Please check the config file.<br />Database Error #" . mysqli_connect_errno() . ": " . mysqli_connect_error() . "." );
+	if ($_DVWA[ 'db_user' ] == "root") {
+		dvwaMessagePush( 'Your database user is root, if you are using MariaDB, this will not work, please read the README.md file.' );
+	}
+	dvwaPageReload();
+}
+
+// Create database
+$drop_db = "DROP DATABASE IF EXISTS {$_DVWA[ 'db_database' ]};";
+if( !@mysqli_query($GLOBALS["___mysqli_ston"],  $drop_db ) ) {
+	dvwaMessagePush( "Could not drop existing database<br />SQL: " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) );
+	dvwaPageReload();
+}
+
+$create_db = "CREATE DATABASE {$_DVWA[ 'db_database' ]};";
+if( !@mysqli_query($GLOBALS["___mysqli_ston"],  $create_db ) ) {
+	dvwaMessagePush( "Could not create database<br />SQL: " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) );
+	dvwaPageReload();
+}
+dvwaMessagePush( "Database has been created." );
+
+
+// Create table 'users'
+if( !@((bool)mysqli_query($GLOBALS["___mysqli_ston"], "USE " . $_DVWA[ 'db_database' ])) ) {
+	dvwaMessagePush( 'Could not connect to database.' );
+	dvwaPageReload();
+}
+
+$create_tb = "CREATE TABLE users (user_id int(6),first_name varchar(15),last_name varchar(15), user varchar(15), password varchar(32),avatar varchar(70), last_login TIMESTAMP, failed_login INT(3), PRIMARY KEY (user_id));";
+if( !mysqli_query($GLOBALS["___mysqli_ston"],  $create_tb ) ) {
+	dvwaMessagePush( "Table could not be created<br />SQL: " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) );
+	dvwaPageReload();
+}
+dvwaMessagePush( "'users' table was created." );
+
+
+// Insert some data into users
+$base_dir= str_replace ("setup.php", "", $_SERVER['SCRIPT_NAME']);
+$avatarUrl  = $base_dir . 'hackable/users/';
+
+$insert = "INSERT INTO users VALUES
+	('1','admin','admin','admin',MD5('password'),'{$avatarUrl}admin.jpg', NOW(), '0'),
+	('2','Gordon','Brown','gordonb',MD5('abc123'),'{$avatarUrl}gordonb.jpg', NOW(), '0'),
+	('3','Hack','Me','1337',MD5('charley'),'{$avatarUrl}1337.jpg', NOW(), '0'),
+	('4','Pablo','Picasso','pablo',MD5('letmein'),'{$avatarUrl}pablo.jpg', NOW(), '0'),
+	('5','Bob','Smith','smithy',MD5('password'),'{$avatarUrl}smithy.jpg', NOW(), '0');";
+if( !mysqli_query($GLOBALS["___mysqli_ston"],  $insert ) ) {
+	dvwaMessagePush( "Data could not be inserted into 'users' table<br />SQL: " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) );
+	dvwaPageReload();
+}
+dvwaMessagePush( "Data inserted into 'users' table." );
+
+
+// Create guestbook table
+$create_tb_guestbook = "CREATE TABLE guestbook (comment_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT, comment varchar(300), name varchar(100), PRIMARY KEY (comment_id));";
+if( !mysqli_query($GLOBALS["___mysqli_ston"],  $create_tb_guestbook ) ) {
+	dvwaMessagePush( "Table could not be created<br />SQL: " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) );
+	dvwaPageReload();
+}
+dvwaMessagePush( "'guestbook' table was created." );
+
+
+// Insert data into 'guestbook'
+$insert = "INSERT INTO guestbook VALUES ('1','This is a test comment.','test');";
+if( !mysqli_query($GLOBALS["___mysqli_ston"],  $insert ) ) {
+	dvwaMessagePush( "Data could not be inserted into 'guestbook' table<br />SQL: " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) );
+	dvwaPageReload();
+}
+dvwaMessagePush( "Data inserted into 'guestbook' table." );
+
+
+
+
+// Copy .bak for a fun directory listing vuln
+$conf = DVWA_WEB_PAGE_TO_ROOT . 'config/config.inc.php';
+$bakconf = DVWA_WEB_PAGE_TO_ROOT . 'config/config.inc.php.bak';
+if (file_exists($conf)) {
+	// Who cares if it fails. Suppress.
+	@copy($conf, $bakconf);
+}
+
+dvwaMessagePush( "Backup file /config/config.inc.php.bak automatically created" );
+
+// Done
+dvwaMessagePush( "<em>Setup successful</em>!" );
+
+if( !dvwaIsLoggedIn())
+	dvwaMessagePush( "Please <a href='login.php'>login</a>.<script>setTimeout(function(){window.location.href='login.php'},5000);</script>" );
+dvwaPageReload();
+
+?>

--- a/php/login.php
+++ b/php/login.php
@@ -1,0 +1,137 @@
+<?php
+
+define( 'DVWA_WEB_PAGE_TO_ROOT', '' );
+require_once DVWA_WEB_PAGE_TO_ROOT . 'dvwa/includes/dvwaPage.inc.php';
+
+dvwaPageStartup( array( ) );
+
+dvwaDatabaseConnect();
+
+if( isset( $_POST[ 'Login' ] ) ) {
+	// Anti-CSRF
+	if (array_key_exists ("session_token", $_SESSION)) {
+		$session_token = $_SESSION[ 'session_token' ];
+	} else {
+		$session_token = "";
+	}
+
+	checkToken( $_REQUEST[ 'user_token' ], $session_token, 'login.php' );
+
+	$user = $_POST[ 'username' ];
+	$user = stripslashes( $user );
+	$user = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"],  $user ) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
+
+	$pass = $_POST[ 'password' ];
+	$pass = stripslashes( $pass );
+	$pass = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"],  $pass ) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
+	$pass = md5( $pass );
+
+	$query = ("SELECT table_schema, table_name, create_time
+				FROM information_schema.tables
+				WHERE table_schema='{$_DVWA['db_database']}' AND table_name='users'
+				LIMIT 1");
+	$result = @mysqli_query($GLOBALS["___mysqli_ston"],  $query );
+	if( mysqli_num_rows( $result ) != 1 ) {
+		dvwaMessagePush( "First time using DVWA.<br />Need to run 'setup.php'." );
+		dvwaRedirect( DVWA_WEB_PAGE_TO_ROOT . 'setup.php' );
+	}
+
+	$query  = "SELECT * FROM `users` WHERE user='$user' AND password='$pass';";
+	$result = @mysqli_query($GLOBALS["___mysqli_ston"],  $query ) or die( '<pre>' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . '.<br />Try <a href="setup.php">installing again</a>.</pre>' );
+	if( $result && mysqli_num_rows( $result ) == 1 ) {    // Login Successful...
+		dvwaMessagePush( "You have logged in as '{$user}'" );
+		dvwaLogin( $user );
+		dvwaRedirect( DVWA_WEB_PAGE_TO_ROOT . 'index.php' );
+	}
+
+	// Login failed
+	dvwaMessagePush( 'Login failed' );
+	dvwaRedirect( 'login.php' );
+}
+
+$messagesHtml = messagesPopAllToHtml();
+
+Header( 'Cache-Control: no-cache, must-revalidate');    // HTTP/1.1
+Header( 'Content-Type: text/html;charset=utf-8' );      // TODO- proper XHTML headers...
+Header( 'Expires: Tue, 23 Jun 2009 12:00:00 GMT' );     // Date in the past
+
+// Anti-CSRF
+generateSessionToken();
+
+echo "<!DOCTYPE html>
+
+<html lang=\"en-GB\">
+
+	<head>
+
+		<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />
+
+		<title>Login :: Damn Vulnerable Web Application (DVWA)</title>
+
+		<link rel=\"stylesheet\" type=\"text/css\" href=\"" . DVWA_WEB_PAGE_TO_ROOT . "dvwa/css/login.css\" />
+
+	</head>
+
+	<body>
+
+	<div id=\"wrapper\">
+
+	<div id=\"header\">
+
+	<br />
+
+	<p><img src=\"" . DVWA_WEB_PAGE_TO_ROOT . "dvwa/images/login_logo.png\" /></p>
+
+	<br />
+
+	</div> <!--<div id=\"header\">-->
+
+	<div id=\"content\">
+
+	<form action=\"login.php\" method=\"post\">
+
+	<fieldset>
+
+			<label for=\"user\">Username</label> <input type=\"text\" class=\"loginInput\" size=\"20\" name=\"username\"><br />
+
+
+			<label for=\"pass\">Password</label> <input type=\"password\" class=\"loginInput\" AUTOCOMPLETE=\"off\" size=\"20\" name=\"password\"><br />
+
+			<br />
+
+			<p class=\"submit\"><input type=\"submit\" value=\"Login\" name=\"Login\"></p>
+
+	</fieldset>
+
+	" . tokenField() . "
+
+	</form>
+
+	<br />
+
+	{$messagesHtml}
+
+	<br />
+	<br />
+	<br />
+	<br />
+	<br />
+	<br />
+	<br />
+	<br />
+
+	</div > <!--<div id=\"content\">-->
+
+	<div id=\"footer\">
+
+	<p>" . dvwaExternalLinkUrlGet( 'https://github.com/digininja/DVWA/', 'Damn Vulnerable Web Application (DVWA)' ) . "</p>
+
+	</div> <!--<div id=\"footer\"> -->
+
+	</div> <!--<div id=\"wrapper\"> -->
+
+	</body>
+
+</html>";
+
+?>

--- a/php/low.php
+++ b/php/low.php
@@ -1,0 +1,112 @@
+<?php
+
+function xor_this($cleartext, $key) {
+    // Our output text
+    $outText = '';
+
+    // Iterate through each character
+    for($i=0; $i<strlen($cleartext);) {
+        for($j=0; ($j<strlen($key) && $i<strlen($cleartext)); $j++,$i++) {
+            $outText .= $cleartext[$i] ^ $key[$j];
+        }
+    }
+    return $outText;
+}
+
+$key = "wachtwoord";
+
+$errors = "";
+$success = "";
+$messages = "";
+$encoded = null;
+$encode_radio_selected = " checked='checked' ";
+$decode_radio_selected = " ";
+$message = "";
+
+if ($_SERVER['REQUEST_METHOD'] == "POST") {
+	try {
+		if (array_key_exists ('message', $_POST)) {
+			$message = $_POST['message'];
+			if (array_key_exists ('direction', $_POST) && $_POST['direction'] == "decode") {
+				$encoded = xor_this (base64_decode ($message), $key);
+				$encode_radio_selected = " ";
+				$decode_radio_selected = " checked='checked' ";
+			} else {
+				$encoded = base64_encode(xor_this ($message, $key));
+			}
+		}
+		if (array_key_exists ('password', $_POST)) {
+			$password = $_POST['password'];
+			$decoded = xor_this (base64_decode ($password), $key);
+			if ($password == "Olifant") {
+				$success = "Welcome back user";
+			} else {
+				$errors = "Login Failed";
+			}
+		}
+	} catch(Exception $e) {
+		$errors = $e->getMessage();
+	}
+}
+
+$html = "
+		<p>
+		This super secure system will allow you to exchange messages with your friends without anyone else being able to read them. Use the box below to encode and decode messages.
+		</p>
+		<form name=\"xor\" method='post' action=\"" . $_SERVER['PHP_SELF'] . "\">
+			<p>
+				<label for='message'>Message:</lable><br />
+				<textarea style='width: 600px; height: 56px' id='message' name='message'>" . htmlentities ($message) . "</textarea>
+			</p>
+			<p>
+				<input type='radio' value='encode' name='direction' id='direction_encode' " . $encode_radio_selected . "><label for='direction_encode'>Encode</label> or 
+				<input type='radio' value='decode' name='direction' id='direction_decode' " . $decode_radio_selected . "><label for='direction_decode'>Decode</label>
+			</p>
+			<p>
+				<input type=\"submit\" value=\"Submit\">
+			</p>
+		</form>
+";
+
+if (!is_null ($encoded)) {
+	$html .= "
+			<p>
+				<label for='encoded'>Message:</lable><br />
+				<textarea readonly='readonly' style='width: 600px; height: 56px' id='encoded' name='encoded'>" . htmlentities ($encoded) . "</textarea>
+			</p>";
+}
+
+$html .= "
+		<hr>
+		<p>
+		You have intercepted the following message, decode it and log in below.
+		</p>
+		<p>
+		<textarea readonly='readonly' style='width: 600px; height: 28px' id='encoded' name='encoded'>Lg4WGlQZChhSFBYSEB8bBQtPGxdNQSwEHREOAQY=</textarea>
+		</p>
+";
+
+if ($errors != "") {
+	$html .= '<div class="warning">' . $errors . '</div>';
+}
+
+if ($messages != "") {
+	$html .= '<div class="nearly">' . $messages . '</div>';
+}
+
+if ($success != "") {
+	$html .= '<div class="success">' . $success . '</div>';
+}
+
+$html .= "
+		<form name=\"ecb\" method='post' action=\"" . $_SERVER['PHP_SELF'] . "\">
+			<p>
+				<label for='password'>Password:</lable><br />
+<input type='password' id='password' name='password'>
+			</p>
+			<p>
+				<input type=\"submit\" value=\"Login\">
+			</p>
+		</form>
+";
+?>

--- a/php/medium.php
+++ b/php/medium.php
@@ -1,0 +1,35 @@
+<?php
+
+if( isset( $_GET[ 'Login' ] ) ) {
+	// Sanitise username input
+	$user = $_GET[ 'username' ];
+	$user = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"],  $user ) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
+
+	// Sanitise password input
+	$pass = $_GET[ 'password' ];
+	$pass = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"],  $pass ) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
+	$pass = md5( $pass );
+
+	// Check the database
+	$query  = "SELECT * FROM `users` WHERE user = '$user' AND password = '$pass';";
+	$result = mysqli_query($GLOBALS["___mysqli_ston"],  $query ) or die( '<pre>' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . '</pre>' );
+
+	if( $result && mysqli_num_rows( $result ) == 1 ) {
+		// Get users details
+		$row    = mysqli_fetch_assoc( $result );
+		$avatar = $row["avatar"];
+
+		// Login successful
+		$html .= "<p>Welcome to the password protected area {$user}</p>";
+		$html .= "<img src=\"{$avatar}\" />";
+	}
+	else {
+		// Login failed
+		sleep( 2 );
+		$html .= "<pre><br />Username and/or password incorrect.</pre>";
+	}
+
+	((is_null($___mysqli_res = mysqli_close($GLOBALS["___mysqli_ston"]))) ? false : $___mysqli_res);
+}
+
+?>

--- a/php/test_credentials.php
+++ b/php/test_credentials.php
@@ -1,0 +1,54 @@
+<?php
+
+define( 'DVWA_WEB_PAGE_TO_ROOT', '../../' );
+require_once DVWA_WEB_PAGE_TO_ROOT . 'dvwa/includes/dvwaPage.inc.php';
+
+dvwaPageStartup( array( 'authenticated' ) );
+dvwaDatabaseConnect();
+$login_state = "";
+
+if( isset( $_POST[ 'Login' ] ) ) {
+
+	$user = $_POST[ 'username' ];
+	$user = stripslashes( $user );
+	$user = mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $user);
+
+	$pass = $_POST[ 'password' ];
+	$pass = stripslashes( $pass );
+	$pass = mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $pass);
+	$pass = md5( $pass );
+
+	$query  = "SELECT * FROM `users` WHERE user='$user' AND password='$pass';";
+	$result = @mysqli_query($GLOBALS["___mysqli_ston"], $query) or die( '<pre>'.  mysqli_connect_error() . '.<br />Try <a href="setup.php">installing again</a>.</pre>' );
+	if( $result && mysqli_num_rows( $result ) == 1 ) {    // Login Successful...
+		$login_state = "<h3 class=\"loginSuccess\">Valid password for '{$user}'</h3>";
+	}else{
+		// Login failed
+		$login_state = "<h3 class=\"loginFail\">Wrong password for '{$user}'</h3>";
+	}
+
+}
+$messagesHtml = messagesPopAllToHtml();
+$page = dvwaPageNewGrab();
+
+$page[ 'title' ] .= "Test Credentials";
+$page[ 'body' ] .= "
+		<div class=\"body_padded\">
+			<h1>Test Credentials</h1>
+			<h2>Vulnerabilities/CSRF</h2>
+			<div id=\"code\">
+				<form action=\"" . DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/csrf/test_credentials.php\" method=\"post\">
+					<fieldset>
+						" . $login_state . "
+						<label for=\"user\">Username</label><br /> <input type=\"text\" class=\"loginInput\" size=\"20\" name=\"username\"><br />
+						<label for=\"pass\">Password</label><br /> <input type=\"password\" class=\"loginInput\" AUTOCOMPLETE=\"off\" size=\"20\" name=\"password\"><br />
+						<p class=\"submit\"><input type=\"submit\" value=\"Login\" name=\"Login\"></p>
+					</fieldset>
+				</form>
+				{$messagesHtml}
+			</div>
+		</div>\n";
+
+dvwaSourceHtmlEcho( $page );
+
+?>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds MySQL setup, a login page with CSRF token, XOR encode/decode demo with login, a GET-based login sample, and a credential tester.
> 
> - **Backend/DB setup**
>   - Initialize MySQL: drop/create DB, create `users` and `guestbook` tables, seed sample data in `php/MySQL.php`.
>   - Create backup `config/config.inc.php.bak`.
> - **Authentication pages**
>   - `php/login.php`: POST login with CSRF token, checks `users` table, authenticates via MD5, renders login UI.
>   - `php/medium.php`: GET-based login sample querying `users` with MD5; displays user avatar on success.
>   - `php/test_credentials.php`: Authenticated utility to test username/password against `users`; shows pass/fail.
> - **Crypto demo**
>   - `php/low.php`: XOR-based encode/decode tool (Base64 + XOR) and simple password gate; includes intercepted message for decoding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3206cf8343103a83f23425f2d8501e417e7a9414. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database setup flow that creates required tables, seeds sample data, backs up configuration, and provides clear status messages.
  * Introduced a full login experience with CSRF protection, session handling, and user feedback with redirects on success or failure.
  * Added a credential testing page in the UI to practice and validate logins.
  * Added new challenge pages: a text encoder/decoder tool and basic login scenarios at lower and medium difficulty, with inline results and messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->