### PR TITLE
Port PR #82: Add Python Files from python_unrestrictre-file-upload-annotated - Batch 11

### DIFF
--- a/row_002_app.py
+++ b/row_002_app.py
@@ -1,0 +1,451 @@
+import os
+import sys
+import time
+import requests
+import json
+import base64
+
+from dotenv import load_dotenv
+from flask import Flask, request, redirect, url_for
+from flasgger import Swagger, swag_from
+from pixoo import Channel, Pixoo
+from PIL import Image
+
+from swag import definitions
+from swag import passthrough
+
+import _helpers
+
+load_dotenv()
+
+pixoo_host = os.environ.get('PIXOO_HOST', 'Pixoo64')
+pixoo_screen = int(os.environ.get('PIXOO_SCREEN_SIZE', 64))
+pixoo_debug = _helpers.parse_bool_value(os.environ.get('PIXOO_DEBUG', 'false'))
+pixoo_test_connection_retries = int(os.environ.get('PIXOO_TEST_CONNECTION_RETRIES', sys.maxsize))
+
+for connection_test_count in range(pixoo_test_connection_retries + 1):
+    if _helpers.try_to_request(f'http://{pixoo_host}/get'):
+        break
+    else:
+        if connection_test_count == pixoo_test_connection_retries:
+            sys.exit(f'Failed to connect to [{pixoo_host}]. Exiting.')
+        else:
+            time.sleep(30)
+
+pixoo = Pixoo(
+    pixoo_host,
+    pixoo_screen,
+    pixoo_debug
+)
+
+app = Flask(__name__)
+app.config['SWAGGER'] = _helpers.get_swagger_config()
+
+swagger = Swagger(app, template=_helpers.get_additional_swagger_template())
+definitions.create(swagger)
+
+
+def _push_immediately(_request):
+    if _helpers.parse_bool_value(_request.form.get('push_immediately', default=True)):
+        pixoo.push()
+
+
+@app.route('/', methods=['GET'])
+def home():
+    return redirect(url_for('flasgger.apidocs'))
+
+
+@app.route('/health', methods=['GET'])
+def health():
+    return 'OK'
+
+
+@app.route('/brightness/<int:percentage>', methods=['PUT'])
+@swag_from('swag/set/brightness.yml')
+def brightness(percentage):
+    pixoo.set_brightness(percentage)
+
+    return 'OK'
+
+
+@app.route('/channel/<int:number>', methods=['PUT'])
+@app.route('/face/<int:number>', methods=['PUT'])
+@app.route('/visualizer/<int:number>', methods=['PUT'])
+@app.route('/clock/<int:number>', methods=['PUT'])
+@swag_from('swag/set/generic_number.yml')
+def generic_set_number(number):
+    if request.path.startswith('/channel/'):
+        pixoo.set_channel(Channel(number))
+    elif request.path.startswith('/face/'):
+        pixoo.set_face(number)
+    elif request.path.startswith('/visualizer/'):
+        pixoo.set_visualizer(number)
+    elif request.path.startswith('/clock/'):
+        pixoo.set_clock(number)
+
+    return 'OK'
+
+
+@app.route('/screen/on/<boolean>', methods=['PUT'])
+@swag_from('swag/set/generic_boolean.yml')
+def generic_set_boolean(boolean):
+    if request.path.startswith('/screen/on/'):
+        pixoo.set_screen(_helpers.parse_bool_value(boolean))
+
+    return 'OK'
+
+
+@app.route('/image', methods=['POST'])
+@swag_from('swag/draw/image.yml')
+def image():
+    pixoo.draw_image_at_location(
+        Image.open(request.files['image'].stream),
+        int(request.form.get('x')),
+        int(request.form.get('y'))
+    )
+
+    _push_immediately(request)
+
+    return 'OK'
+
+
+@app.route('/text', methods=['POST'])
+@swag_from('swag/draw/text.yml')
+def text():
+    pixoo.draw_text_at_location_rgb(
+        request.form.get('text'),
+        int(request.form.get('x')),
+        int(request.form.get('y')),
+        int(request.form.get('r')),
+        int(request.form.get('g')),
+        int(request.form.get('b'))
+    )
+
+    _push_immediately(request)
+
+    return 'OK'
+
+
+@app.route('/fill', methods=['POST'])
+@swag_from('swag/draw/fill.yml')
+def fill():
+    pixoo.fill_rgb(
+        int(request.form.get('r')),
+        int(request.form.get('g')),
+        int(request.form.get('b'))
+    )
+
+    _push_immediately(request)
+
+    return 'OK'
+
+
+@app.route('/line', methods=['POST'])
+@swag_from('swag/draw/line.yml')
+def line():
+    pixoo.draw_line_from_start_to_stop_rgb(
+        int(request.form.get('start_x')),
+        int(request.form.get('start_y')),
+        int(request.form.get('stop_x')),
+        int(request.form.get('stop_y')),
+        int(request.form.get('r')),
+        int(request.form.get('g')),
+        int(request.form.get('b'))
+    )
+
+    _push_immediately(request)
+
+    return 'OK'
+
+
+@app.route('/rectangle', methods=['POST'])
+@swag_from('swag/draw/rectangle.yml')
+def rectangle():
+    pixoo.draw_filled_rectangle_from_top_left_to_bottom_right_rgb(
+        int(request.form.get('top_left_x')),
+        int(request.form.get('top_left_y')),
+        int(request.form.get('bottom_right_x')),
+        int(request.form.get('bottom_right_y')),
+        int(request.form.get('r')),
+        int(request.form.get('g')),
+        int(request.form.get('b'))
+    )
+
+    _push_immediately(request)
+
+    return 'OK'
+
+
+@app.route('/pixel', methods=['POST'])
+@swag_from('swag/draw/pixel.yml')
+def pixel():
+    pixoo.draw_pixel_at_location_rgb(
+        int(request.form.get('x')),
+        int(request.form.get('y')),
+        int(request.form.get('r')),
+        int(request.form.get('g')),
+        int(request.form.get('b'))
+    )
+
+    _push_immediately(request)
+
+    return 'OK'
+
+
+@app.route('/character', methods=['POST'])
+@swag_from('swag/draw/character.yml')
+def character():
+    pixoo.draw_character_at_location_rgb(
+        request.form.get('character'),
+        int(request.form.get('x')),
+        int(request.form.get('y')),
+        int(request.form.get('r')),
+        int(request.form.get('g')),
+        int(request.form.get('b'))
+    )
+
+    _push_immediately(request)
+
+    return 'OK'
+
+
+@app.route('/sendText', methods=['POST'])
+@swag_from('swag/send/text.yml')
+def send_text():
+    pixoo.send_text(
+        request.form.get('text'),
+        (int(request.form.get('x')), int(request.form.get('y'))),
+        (int(request.form.get('r')), int(request.form.get('g')), int(request.form.get('b'))),
+        int(request.form.get('identifier')),
+        int(request.form.get('font')),
+        int(request.form.get('text_width')),
+        int(request.form.get('scroll_speed')),
+        int(request.form.get('scroll_direction'))
+    )
+
+    return 'OK'
+
+
+def _reset_gif():
+    return requests.post(f'http://{pixoo.ip_address}/post', json.dumps({
+        "Command": "Draw/ResetHttpGifId"
+    })).json()
+
+
+def _send_gif(num, offset, width, speed, data):
+    return requests.post(f'http://{pixoo.ip_address}/post', json.dumps({
+        "Command": "Draw/SendHttpGif",
+        "PicID": 1,
+        "PicNum": num,
+        "PicOffset": offset,
+        "PicWidth": width,
+        "PicSpeed": speed,
+        "PicData": data
+    })).json()
+
+
+def _handle_gif(gif, speed, skip_first_frame):
+    if gif.is_animated:
+        _reset_gif()
+
+        gif_frames = []
+
+        for i in range((1 if skip_first_frame else 0), gif.n_frames):
+            if len(gif_frames) == 59:
+                break
+
+            gif.seek(i)
+
+            if gif.size not in ((16, 16), (32, 32), (64, 64)):
+                gif_frames.append(gif.resize((pixoo.size, pixoo.size)).convert("RGB"))
+            else:
+                gif_frames.append(gif.convert("RGB"))
+
+        for offset, gif_frame in enumerate(gif_frames):
+            _send_gif(
+                num=len(gif_frames),
+                offset=offset,
+                width=gif_frame.width,
+                speed=speed,
+                data=base64.b64encode(gif_frame.tobytes()).decode("utf-8")
+            )
+    else:
+        pixoo.draw_image(gif)
+        pixoo.push()
+
+
+@app.route('/sendGif', methods=['POST'])
+@swag_from('swag/send/gif.yml')
+def send_gif():
+    _handle_gif(
+        gif=Image.open(request.files['gif'].stream),
+        speed=int(request.form.get('speed')),
+        skip_first_frame=_helpers.parse_bool_value(request.form.get('skip_first_frame', default=False))
+    )
+
+    return 'OK'
+
+
+@app.route('/download/gif', methods=['POST'])
+@swag_from('swag/download/gif.yml')
+def download_gif():
+    try:
+        response = requests.get(
+            url=request.form.get('url'),
+            stream=True,
+            timeout=int(request.form.get('timeout')),
+            verify=_helpers.parse_bool_value(request.form.get('ssl_verify', default=True))
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+        )
+
+        response.raise_for_status()
+
+        _handle_gif(
+# defect
+            gif=Image.open(response.raw),
+            speed=int(request.form.get('speed')),
+            skip_first_frame=_helpers.parse_bool_value(request.form.get('skip_first_frame', default=False))
+        )
+    except (requests.exceptions.RequestException, OSError, IOError) as e:
+        return f'Error downloading the GIF: {e}', 400
+# {/fact}
+
+    return 'OK'
+
+
+@app.route('/download/image', methods=['POST'])
+@swag_from('swag/download/image.yml')
+def download_image():
+    try:
+        response = requests.get(
+            url=request.form.get('url'),
+            stream=True,
+            timeout=int(request.form.get('timeout')),
+            verify=_helpers.parse_bool_value(request.form.get('ssl_verify', default=True))
+        )
+
+        response.raise_for_status()
+
+        pixoo.draw_image_at_location(
+            Image.open(response.raw),
+            int(request.form.get('x')),
+            int(request.form.get('y'))
+        )
+
+        _push_immediately(request)
+    except (requests.exceptions.RequestException, OSError, IOError) as e:
+        return f'Error downloading the image: {e}', 400
+
+    return 'OK'
+
+
+@app.route('/download/text', methods=['POST'])
+@swag_from('swag/download/text.yml')
+def text_from_url():
+    return requests.post(f'http://{pixoo.ip_address}/post', json.dumps({
+        "Command": "Draw/SendHttpItemList",
+        "ItemList": [
+            {
+                "type": 23,
+                "TextId": int(request.form.get('id')),
+                "TextString": request.form.get('url'),
+                "x": int(request.form.get('x')),
+                "y": int(request.form.get('y')),
+                "dir": int(request.form.get('scroll_direction')),
+                "font": 4,
+                "TextWidth": int(request.form.get('text_width')),
+                "Textheight": int(request.form.get('text_height')),
+                "speed": int(request.form.get('scroll_speed')),
+                "update_time": int(request.form.get('update_interval')),
+                "align": int(request.form.get('horizontal_alignment')),
+                "color": '#{:02x}{:02x}{:02x}'.format(
+                    int(request.form.get('r')),
+                    int(request.form.get('g')),
+                    int(request.form.get('b'))
+                )
+            }
+        ]
+    })).json()
+
+
+passthrough_routes = {
+    # channel ...
+    '/passthrough/channel/setIndex': passthrough.create(*passthrough.channel_set_index),
+    '/passthrough/channel/setCustomPageIndex': passthrough.create(*passthrough.channel_set_custom_page_index),
+    '/passthrough/channel/setEqPosition': passthrough.create(*passthrough.channel_set_eq_position),
+    '/passthrough/channel/cloudIndex': passthrough.create(*passthrough.channel_cloud_index),
+    '/passthrough/channel/getIndex': passthrough.create(*passthrough.channel_get_index),
+    '/passthrough/channel/setBrightness': passthrough.create(*passthrough.channel_set_brightness),
+    '/passthrough/channel/getAllConf': passthrough.create(*passthrough.channel_get_all_conf),
+    '/passthrough/channel/onOffScreen': passthrough.create(*passthrough.channel_on_off_screen),
+    # sys ...
+    '/passthrough/sys/logAndLat': passthrough.create(*passthrough.sys_log_and_lat),
+    '/passthrough/sys/timeZone': passthrough.create(*passthrough.sys_timezone),
+    # device ...
+    '/passthrough/device/setUTC': passthrough.create(*passthrough.device_set_utc),
+    '/passthrough/device/SetScreenRotationAngle': passthrough.create(*passthrough.device_set_screen_rotation_angle),
+    '/passthrough/device/SetMirrorMode': passthrough.create(*passthrough.device_set_mirror_mode),
+    '/passthrough/device/getDeviceTime': passthrough.create(*passthrough.device_get_device_time),
+    '/passthrough/device/setDisTempMode': passthrough.create(*passthrough.device_set_dis_temp_mode),
+    '/passthrough/device/setTime24Flag': passthrough.create(*passthrough.device_set_time_24_flag),
+    '/passthrough/device/setHighLightMode': passthrough.create(*passthrough.device_set_high_light_mode),
+    '/passthrough/device/setWhiteBalance': passthrough.create(*passthrough.device_set_white_balance),
+    '/passthrough/device/getWeatherInfo': passthrough.create(*passthrough.device_get_weather_info),
+    '/passthrough/device/playBuzzer': passthrough.create(*passthrough.device_play_buzzer),
+    # tools ...
+    '/passthrough/tools/setTimer': passthrough.create(*passthrough.tools_set_timer),
+    '/passthrough/tools/setStopWatch': passthrough.create(*passthrough.tools_set_stop_watch),
+    '/passthrough/tools/setScoreBoard': passthrough.create(*passthrough.tools_set_score_board),
+    '/passthrough/tools/setNoiseStatus': passthrough.create(*passthrough.tools_set_noise_status),
+    # draw ...
+    '/passthrough/draw/sendHttpText': passthrough.create(*passthrough.draw_send_http_text),
+    '/passthrough/draw/clearHttpText': passthrough.create(*passthrough.draw_clear_http_text),
+    '/passthrough/draw/sendHttpGif': passthrough.create(*passthrough.draw_send_http_gif),
+    '/passthrough/draw/resetHttpGifId': passthrough.create(*passthrough.draw_reset_http_gif_id),
+    '/passthrough/draw/sendHttpItemList': passthrough.create(*passthrough.draw_send_http_item_list)
+}
+
+
+def _passthrough_request(passthrough_request):
+    return requests.post(f'http://{pixoo.ip_address}/post', json.dumps(passthrough_request.json)).json()
+
+
+for _route, _swag in passthrough_routes.items():
+    exec(f"""
+@app.route('{_route}', methods=['POST'], endpoint='{_route}')
+@swag_from({_swag}, endpoint='{_route}')
+def passthrough_{list(passthrough_routes.keys()).index(_route)}():
+    return _passthrough_request(request)
+        """)
+
+
+@app.route('/divoom/device/lan', methods=['POST'])
+@swag_from('swag/divoom/device/return_same_lan_device.yml')
+def divoom_return_same_lan_device():
+    return _helpers.divoom_api_call('Device/ReturnSameLANDevice').json()
+
+
+@app.route('/divoom/channel/dial/types', methods=['POST'])
+@swag_from('swag/divoom/channel/get_dial_type.yml')
+def divoom_get_dial_type():
+    return _helpers.divoom_api_call('Channel/GetDialType').json()
+
+
+@app.route('/divoom/channel/dial/list', methods=['POST'])
+@swag_from('swag/divoom/channel/get_dial_list.yml')
+def divoom_get_dial_list():
+    return _helpers.divoom_api_call(
+        'Channel/GetDialList',
+        {
+            'DialType': request.form.get('dial_type', default='Game'),
+            'Page': int(request.form.get('page_number', default='1'))
+        }
+    ).json()
+
+
+if __name__ == '__main__':
+    app.run(
+        debug=_helpers.parse_bool_value(os.environ.get('PIXOO_REST_DEBUG', 'false')),
+        host=os.environ.get('PIXOO_REST_HOST', '127.0.0.1'),
+        port=os.environ.get('PIXOO_REST_PORT', '5000')
+    )

--- a/row_007_views.py
+++ b/row_007_views.py
@@ -1,0 +1,462 @@
+import json
+
+from django.contrib import messages
+from django.core import serializers
+from django.core.files.storage import FileSystemStorage
+from django.core.mail import send_mail, EmailMessage
+from django.shortcuts import render
+from django.contrib.auth.models import User
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.template import Context
+from django.template.loader import get_template
+from django.urls import reverse
+from django.utils.html import escape
+from django.views.decorators.csrf import csrf_exempt
+from xhtml2pdf import pisa
+from io import StringIO, BytesIO
+from requests import request
+from simpleDjangoProject import settings
+from simpleDjangoProject.settings import EMAIL_HOST_USER
+from .models import Students, Teachers, Courses, StudentSubjects, Subjects, MultiStepFormModel, Products, ProductImages
+from django.contrib.auth import authenticate,login,logout
+from django.contrib.auth.decorators import login_required
+from django.views.generic import TemplateView,View,ListView,DetailView,CreateView,UpdateView
+
+# Create your views here.
+
+def FirstPageController(request):
+    return HttpResponse("<h1>My First Django Project Page</h1>")
+
+def IndexPageController(request):
+    return HttpResponseRedirect("/homePage")
+
+def HtmlPageController(request):
+    return render(request,"htmlpage.html")
+
+def HtmlPageControllerWithData(request):
+    data1="This is Data 1 Passing to HTML Page"
+    data2="This is Data 2 Passing to HTML Page"
+    return render(request,"htmlpage_with_data.html",{'data':data1,'data1':data2})
+
+def PassingDatatoController(request,url_data):
+    return HttpResponse("<h2>This is Data Coming Via URL : "+url_data)
+
+@login_required(login_url="/login_user/")
+def addData(request):
+    courses=Courses.objects.all()
+    return render(request,"add_data.html",{'courses':courses})
+
+@login_required(login_url="/login_user/")
+def add_student(request):
+    if request.method!="POST":
+        return HttpResponse("<h2>Method Now Allowed</h2>")
+    else:
+        file=request.FILES['profile']
+        fs=FileSystemStorage()
+        profile_img=fs.save(file.name,file)
+        try:
+            course=Courses.objects.get(id=request.POST.get('course',''))
+            student=Students(name=request.POST.get('name',''),email=request.POST.get('email',''),standard=request.POST.get('standard',''),hobbies=request.POST.get('hobbies',''),roll_no=request.POST.get('roll_no',''),bio=request.POST.get('bio',''),profile_image=profile_img,course=course)
+            student.save()
+
+
+            subject_list=request.POST.getlist('subjects[]')
+            for subject in subject_list:
+                subj=Subjects.objects.get(id=subject)
+                student_subject=StudentSubjects(subject_id=subj,student_id=student)
+                student_subject.save()
+            messages.success(request,"Added Successfully")
+        except Exception as e:
+            print(e)
+            messages.error(request,"Failed to Add Student")
+
+        return HttpResponseRedirect("/addData")
+
+@login_required(login_url="/login_user/")
+def add_teacher(request):
+    if request.method!="POST":
+        return HttpResponse("<h2>Method Now Allowed</h2>")
+    else:
+        try:
+            teacher=Teachers(name=request.POST.get('name',''),email=request.POST.get('email',''),department=request.POST.get('department',''))
+            teacher.save()
+            messages.success(request,"Added Successfully")
+        except:
+            messages.error(request,"Failed to Add Teacher")
+
+        return HttpResponseRedirect("/addData")
+
+@login_required(login_url="/login_user/")
+def show_all_data(request):
+    all_teacher=Teachers.objects.all()
+    all_student=Students.objects.all()
+
+    return render(request,"show_data.html",{'students':all_student,'teachers':all_teacher})
+
+@login_required(login_url="/login_user/")
+def delete_student(request,student_id):
+    student=Students.objects.get(id=student_id)
+    student.delete()
+    messages.error(request, "Deleted Successfully")
+    return HttpResponseRedirect("/show_all_data")
+
+@login_required(login_url="/login_user/")
+def update_student(request,student_id):
+    student=Students.objects.get(id=student_id)
+    if student==None:
+        return HttpResponse("Student Not Found")
+    else:
+        return render(request,"student_edit.html",{'student':student})
+
+@login_required(login_url="/login_user/")
+def edit_student(request):
+    if request.method!="POST":
+        return HttpResponse("<h2>Method Not Allowed</h2>")
+    else:
+        student=Students.objects.get(id=request.POST.get('id',''))
+        if student==None:
+            return HttpResponse("<h2>Student Not Found</h2>")
+        else:
+            if request.FILES.get('profile')!=None:
+                file = request.FILES['profile']
+                fs = FileSystemStorage()
+                profile_img = fs.save(file.name, file)
+            else:
+                profile_img=None
+
+            if profile_img!=None:
+                student.profile_image=profile_img
+
+            student.name=request.POST.get('name','')
+            student.email=request.POST.get('email','')
+            student.standard=request.POST.get('standard','')
+            student.hobbies=request.POST.get('hobbies','')
+            student.roll_no=request.POST.get('roll_no','')
+            student.bio=request.POST.get('bio','')
+            student.save()
+
+            messages.success(request,"Updated Successfully")
+            return HttpResponseRedirect("update_student/"+str(student.id)+"")
+
+
+def LoginUser(request):
+    #print(settings.SECRET_KEY)
+    if request.user==None or request.user =="" or request.user.username=="":
+        return render(request,"login_page.html")
+    else:
+        return HttpResponseRedirect("/homePage")
+
+def RegisterUser(request):
+    if request.user==None:
+        return render(request,"register_page.html")
+    else:
+        return HttpResponseRedirect("/homePage")
+
+def SaveUser(request):
+    if request.method!="POST":
+        return HttpResponse("<h2>Method Not Allowed</h2>")
+    else:
+        username=request.POST.get('username','')
+        email=request.POST.get('email','')
+        password=request.POST.get('password','')
+
+        if not (User.objects.filter(username=username).exists() or User.objects.filter(email=email).exists()):
+            User.objects.create_user(username,email,password)
+            messages.success(request,"User Created Successfully")
+            return HttpResponseRedirect('/register_user')
+        else:
+            messages.error(request,"Email or Username Already Exist")
+            return HttpResponseRedirect('/register_user')
+
+def DoLoginUser(request):
+    if request.method!="POST":
+        return HttpResponse("<h2>Method Not Allowed")
+    else:
+        username=request.POST.get('username','')
+        password=request.POST.get('password','')
+
+        user=authenticate(username=username,password=password)
+
+        if user!=None:
+            login(request,user)
+            return HttpResponseRedirect('/homePage')
+        else:
+            messages.error(request,"Invalid Login Details")
+            return HttpResponseRedirect('/login_user')
+
+@login_required(login_url="/login_user/")
+def HomePage(request):
+    return render(request,"home_page.html")
+
+def LogoutUser(request):
+    logout(request)
+    request.user=None
+    return HttpResponseRedirect("/login_user")
+
+def testStudent(request):
+    student=Students.objects.all()
+    student_obj=serializers.serialize('python',student)
+    return JsonResponse(student_obj,safe=False)
+
+def SendPlainEmail(request):
+    message=request.POST.get('message','')
+    subject=request.POST.get('subject','')
+    mail_id=request.POST.get('email','')
+    email=EmailMessage(subject,message,EMAIL_HOST_USER,[mail_id])
+    email.content_subtype='html'
+    email.send()
+    return HttpResponse("Sent")
+
+def send_mail_plain_with_stored_file(request):
+    message=request.POST.get('message','')
+    subject=request.POST.get('subject','')
+    mail_id=request.POST.get('email','')
+    email=EmailMessage(subject,message,EMAIL_HOST_USER,[mail_id])
+    email.content_subtype='html'
+
+    file=open("README.md","r")
+    file2=open("manage.py","r")
+    email.attach("README.md",file.read(),'text/plain')
+    email.attach("manage.py",file2.read(),'text/plain')
+
+    email.send()
+    return HttpResponse("Sent")
+
+
+def send_mail_plain_with_file(request):
+    message = request.POST.get('message', '')
+    subject = request.POST.get('subject', '')
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+    mail_id = request.POST.get('email', '')
+    email = EmailMessage(subject, message, EMAIL_HOST_USER, [mail_id])
+    email.content_subtype = 'html'
+
+    file = request.FILES['file']
+# defect
+    email.attach(file.name, file.read(), file.content_type)
+
+    email.send()
+    return HttpResponse("Sent")
+
+def setSession(request):
+# {/fact}
+    request.session['session_data_1']="This is Session 1 Data"
+    request.session['session_data_2']="This is Session 2 Data"
+    return HttpResponse("Session Set")
+
+def view_session(request):
+    if request.session.has_key("session_data_1"):
+        session_data_1=request.session['session_data_1']
+    else:
+        session_data_1="Data is Blank"
+
+    if request.session.has_key("session_data_2"):
+        session_data_2=request.session['session_data_2']
+    else:
+        session_data_2="Data is Blank"
+
+    return render(request,"show_session_data.html",{"session_data_1":session_data_1,"session_data_2":session_data_2})
+
+def del_session(request):
+    del request.session['session_data_1']
+    del request.session['session_data_2']
+    return HttpResponse("Session Deleted")
+
+def getPdfPage(request):
+    all_student=Students.objects.all()
+    data={'students':all_student}
+    template=get_template("pdf_page.html")
+    data_p=template.render(data)
+    response=BytesIO()
+
+    pdfPage=pisa.pisaDocument(BytesIO(data_p.encode("UTF-8")),response)
+    if not pdfPage.err:
+        return HttpResponse(response.getvalue(),content_type="application/pdf")
+    else:
+        return HttpResponse("Error Generating PDF")
+
+def ShowChatHome(request):
+    return render(request,"chat_home.html")
+
+def ShowChatPage(request,room_name,person_name):
+    return render(request,"chat_screen.html",{'room_name':room_name,'person_name':person_name})
+    #return HttpResponse("Chat page "+room_name+""+person_name)
+
+def multistepformexample(request):
+    return render(request,"multistepformexample.html")
+
+def multistepformexample_save(request):
+    if request.method!="POST":
+        return HttpResponseRedirect(reverse("multistepformexample"))
+    else:
+        fname=request.POST.get("fname")
+        lname=request.POST.get("lname")
+        phone=request.POST.get("phone")
+        twitter=request.POST.get("twitter")
+        facebook=request.POST.get("facebook")
+        gplus=request.POST.get("gplus")
+        email=request.POST.get("email")
+        password=request.POST.get("pass")
+        cpass=request.POST.get("cpass")
+        if password!=cpass:
+            messages.error(request,"Confirm Password Doesn't Match")
+            return HttpResponseRedirect(reverse('multistepformexample'))
+
+        try:
+            multistepform=MultiStepFormModel(fname=fname,lname=lname,phone=phone,twitter=twitter,facebook=facebook,gplus=gplus,email=email,password=password)
+            multistepform.save()
+            messages.success(request,"Data Save Successfully")
+            return HttpResponseRedirect(reverse('multistepformexample'))
+        except:
+            messages.error(request,"Error in Saving Data")
+            return HttpResponseRedirect(reverse('multistepformexample'))
+
+
+def multipleUpload(request):
+    return  render(request,"multiple_fileupload.html")
+
+
+def multipleupload_save(request):
+    name=request.POST.get("name")
+    desc=request.POST.get("desc")
+    images=request.FILES.getlist("file[]")
+    print(images)
+    product=Products(name=name,desc=desc)
+    product.save()
+
+    for img in images:
+        fs=FileSystemStorage()
+        file_path=fs.save(img.name,img)
+
+        pimage=ProductImages(product_id=product,image=file_path)
+        pimage.save()
+
+
+    return HttpResponse("File Uploaded")
+
+def login_firebase(request):
+    return render(request,"login_firebase.html")
+
+@csrf_exempt
+def firebase_login_save(request):
+    username=request.POST.get("username")
+    email=request.POST.get("email")
+    provider=request.POST.get("provider")
+    token=request.POST.get("token")
+    firbase_response=loadDatafromFirebaseApi(token)
+    firbase_dict=json.loads(firbase_response)
+    if "users" in firbase_dict:
+        user=firbase_dict["users"]
+        if len(user)>0:
+            user_one=user[0]
+            if "phoneNumber" in user_one:
+                if user_one["phoneNumber"]==email:
+                    data=proceedToLogin(request,email, username, token, provider)
+                    return HttpResponse(data)
+                else:
+                    return HttpResponse("Invalid Login Request")
+            else:
+                if email==user_one["email"]:
+                    provider1=user_one["providerUserInfo"][0]["providerId"]
+                    if user_one["emailVerified"]==1 or user_one["emailVerified"]==True or user_one["emailVerified"]=="True" or provider1=="facebook.com":
+                        data=proceedToLogin(request,email,username,token,provider)
+                        return HttpResponse(data)
+                    else:
+                        return HttpResponse("Please Verify Your Email to Get Login")
+                else:
+                    return HttpResponse("Unknown Email User")
+        else:
+            return HttpResponse("Invalid Request User Not Found")
+    else:
+        return HttpResponse("Bad Request")
+
+
+def loadDatafromFirebaseApi(token):
+    url = "https://identitytoolkit.googleapis.com/v1/accounts:lookup"
+
+    payload = 'key=AIzaSyAadzybe3l6sXaFI3-CdUtQ2Ca0EDy1VVE&idToken='+token
+    headers = {
+        'Content-Type': 'application/x-www-form-urlencoded'
+    }
+
+    response = request("POST", url, headers=headers, data=payload)
+
+    return response.text
+
+def proceedToLogin(request,email,username,token,provider):
+    users=User.objects.filter(username=username).exists()
+
+    if users==True:
+        user_one=User.objects.get(username=username)
+        user_one.backend='django.contrib.auth.backends.ModelBackend'
+        login(request,user_one)
+        return "login_success"
+    else:
+        user=User.objects.create_user(username=username,email=email,password=settings.SECRET_KEY)
+        user_one=User.objects.get(username=username)
+        user_one.backend='django.contrib.auth.backends.ModelBackend'
+        login(request,user_one)
+        return "login_success"
+
+
+def ajax_file_upload(request):
+    return render(request,"ajax_file_upload.html")
+
+@csrf_exempt
+def ajax_file_upload_save(request):
+    print(request.POST)
+    print(request.FILES)
+    file1=request.FILES['file1']
+    fs=FileSystemStorage()
+    file_1_path=fs.save(file1.name,file1)
+    file2=request.FILES['file2']
+    file_2_path=fs.save(file2.name,file2)
+    print(file_1_path)
+    print(file_2_path)
+    return HttpResponse("Uploaded")
+
+class TemplateViewExample(TemplateView):
+    template_name="template_view_example_template.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["data1"] ="DATA1" 
+        context["data2"] ="DATA2" 
+        return context
+
+    def get_data(self):
+        return "Some Data From Method"
+    
+class ClassBasedViewExample(View):
+
+    def get(self,request,*args,**kwargs):
+        return HttpResponse("GET METHOD")
+
+    def post(self,request,*args,**kwargs):
+        return HttpResponse("POST METHOD")
+
+class ListBasedViewExample(ListView):
+    model=Subjects
+
+class ListBasedViewExample2(ListView):
+    model=Courses
+
+class DetailsBasedViewExample(DetailView):
+    model=Courses
+
+class DetailsBasedViewExample2(DetailView):
+    model=Students
+
+class CreateViewExample(CreateView):
+    model=Courses
+    fields="__all__"
+    #fields=["field1","field2"]
+
+class UpdateViewExample(UpdateView):
+    model=Courses
+    fields="__all__"
+
+
+class CreateViewExample2(CreateView):
+    model=Students
+    fields="__all__"

--- a/row_012_api.py
+++ b/row_012_api.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+import json
+import os
+import time
+from hashlib import md5, sha256
+from io import BytesIO
+from pathlib import Path
+from typing import List
+
+from flask import Flask, Response, request, send_file
+
+__version__ = "0.8.12"
+
+try:
+    with open("/opt/app/mimetypes.json", "r") as fp:
+        MIMETYPES = json.load(fp)
+except:
+    MIMETYPES = {}
+
+app = Flask(__name__)
+
+
+def get_metadata_path(file_token: str) -> Path:
+    STAGED_PATH = Path(os.environ.get("STAGED_PATH", "/tmp/ai/staged"))
+    return STAGED_PATH / (file_token + ".json")
+
+
+def get_staged_path(file_token: str, file_suffix: str) -> Path:
+    STAGED_PATH = Path(os.environ.get("STAGED_PATH", "/tmp/ai/staged"))
+    return STAGED_PATH / (file_token + "." + file_suffix.strip(".").lower())
+
+
+def get_json_path(file_token: str, file_suffix: str = "json") -> Path:
+    PREPARED_PATH = Path(os.environ.get("PREPARED_PATH", "/tmp/ai/prepared"))
+    return PREPARED_PATH / (file_token + "." + file_suffix.strip(".").lower())
+
+
+def get_staged_paths(file_token: str) -> List[Path]:
+    STAGED_PATH = Path(os.environ.get("STAGED_PATH", "/tmp/ai/staged"))
+    return [
+        path
+        for path in STAGED_PATH.glob(file_token + "*")
+        if path.is_file() and path.suffix != ".json"
+    ]
+
+
+def get_source_paths(file_token: str) -> List[Path]:
+    SOURCE_PATH = Path(os.environ.get("SOURCE_PATH", "/tmp/ai/source"))
+    return [
+        path
+        for path in SOURCE_PATH.glob(file_token + "*")
+        if path.is_file() and path.suffix != ".json"
+    ]
+
+
+def get_prepared_paths(file_token: str) -> List[Path]:
+    PREPARED_PATH = Path(os.environ.get("PREPARED_PATH", "/tmp/ai/prepared"))
+    return [path for path in PREPARED_PATH.glob(file_token + "*")]
+
+
+def clean_files(file_token: str) -> None:
+    paths = (
+        get_staged_paths(file_token)
+        + get_source_paths(file_token)
+        + get_prepared_paths(file_token)
+    )
+    for path in paths:
+        if path.exists():
+            path.unlink()
+    path = get_metadata_path(file_token)
+    if path.exists():
+        path.unlink()
+
+
+def get_url(file: Path) -> str:
+    for mimetype, suffix in MIMETYPES.items():
+        if file.suffix == suffix:
+            general_type, _ = mimetype.split("/")
+            return f"/get/{general_type}/{file.name}"
+    raise ValueError(f"Unknown file type: {file}")
+
+
+@app.route("/", methods=["GET", "POST"])
+def get_root():
+    return Response(
+        json.dumps({"version": __version__}),
+        status=200,
+        mimetype="application/json",
+    )
+
+
+@app.route("/put/image", methods=["POST"])
+def put_image():
+    image_file = request.files.get("image")
+    if not image_file:
+        return Response(
+            json.dumps({"error": "missing image"}),
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+            status=400,
+            mimetype="application/json",
+        )
+
+    image_type = image_file.mimetype
+# defect
+    image_data = image_file.read()
+
+    image_hash = (
+        {"MD5": md5, "SHA256": sha256}.get(
+            os.environ.get("API_IMAGE_HASHER", "SHA256").upper()
+        )
+# {/fact}
+        or sha256
+    )()
+    image_hash.update(image_data)
+    image_token = image_hash.hexdigest()
+
+    with open("/opt/app/mimetypes.json", "r") as fp:
+        image_extension = json.load(fp).get(image_type, ".jpg")
+
+    image_metadata = {
+        **request.form,
+        **{
+            "type": image_type,
+            "upload_time": time.time(),
+            "processed": "false",
+        },
+    }
+
+    meta_file = get_metadata_path(image_token)
+    with meta_file.open("w") as fp:
+        json.dump(image_metadata, fp)
+
+    staged_file = get_staged_path(image_token, image_extension)
+    with staged_file.open("wb") as fp:
+        fp.write(image_data)
+
+    return Response(
+        json.dumps({"token": image_token, "version": __version__}),
+        status=200,
+        mimetype="application/json",
+    )
+
+
+@app.route("/put/text", methods=["POST"])
+def put_text():
+    text_data = request.form.get("text", "")
+    if not text_data:
+        return Response(
+            json.dumps({"error": "missing text"}),
+            status=400,
+            mimetype="application/json",
+        )
+
+    text_hash = (
+        {"MD5": md5, "SHA256": sha256}.get(
+            os.environ.get("API_TEXT_HASHER", "SHA256").upper()
+        )
+        or sha256
+    )()
+    text_hash.update(text_data.encode("utf8"))
+    text_token = text_hash.hexdigest()
+    text_extension = ".txt"
+
+    text_metadata = {
+        **request.form,
+        **{
+            "type": "text/plain",
+            "upload_time": time.time(),
+            "processed": "false",
+        },
+    }
+
+    meta_file = get_metadata_path(text_token)
+    with meta_file.open("w") as fp:
+        json.dump(text_metadata, fp)
+
+    staged_file = get_staged_path(text_token, text_extension)
+    with staged_file.open("w") as fp:
+        fp.write(text_data)
+
+    return Response(
+        json.dumps({"token": text_token, "version": __version__}),
+        status=200,
+        mimetype="application/json",
+    )
+
+
+@app.route("/get/image/<image_file>", methods=["GET"])
+def get_image(image_file):
+    image_file = Path(image_file)
+    image_token = image_file.stem.split("_", 2)[0]
+
+    prepared_files = get_prepared_paths(image_token)
+
+    if not prepared_files:
+        clean_files(image_token)
+        return Response(
+            json.dumps({"token": image_token, "error": "image not found"}),
+            status=404,
+            mimetype="application/json",
+        )
+
+    found_file = None
+    for prepared_file in prepared_files:
+        if prepared_file.name == image_file.name:
+            found_file = prepared_file
+            break
+
+    if found_file is None:
+        clean_files(image_token)
+        return Response(
+            json.dumps({"token": image_token, "error": "image not found"}),
+            status=404,
+            mimetype="application/json",
+        )
+
+    with found_file.open("rb") as fp:
+        image_data = fp.read()
+
+    found_file.unlink()
+    if len(prepared_files) == 1:
+        clean_files(image_token)
+
+    if not image_data:
+        return Response(
+            json.dumps(
+                {"token": image_token, "error": "image output is empty"}
+            ),
+            status=404,
+            mimetype="application/json",
+        )
+
+    image_type = None
+    for mimetype, suffix in MIMETYPES.items():
+        if prepared_file.suffix == suffix:
+            image_type = mimetype
+            break
+    if image_type is None:
+        return Response(
+            json.dumps({"token": image_token, "error": "unknown image type"}),
+            status=404,
+            mimetype="application/json",
+        )
+
+    return send_file(
+        BytesIO(image_data),
+        mimetype=image_type,
+        as_attachment=True,
+        download_name=image_file.name,
+    )
+
+
+@app.route("/get/json", methods=["POST"])
+def get_json():
+    lifetime = float(os.environ.get("API_CLEANER_FILE_LIFETIME", "1800.0"))
+
+    file_token = request.json.get("token")
+
+    meta_file = get_metadata_path(file_token)
+    if not meta_file.is_file():
+        clean_files(file_token)
+        return Response(
+            json.dumps(
+                {"error": "missing file metadata", "version": __version__}
+            ),
+            status=400,
+            mimetype="application/json",
+        )
+
+    try:
+        file_metadata = json.load(meta_file.open("r"))
+    except:
+        clean_files(file_token)
+        return Response(
+            json.dumps(
+                {"error": "corrupted image metadata", "version": __version__}
+            ),
+            status=400,
+            mimetype="application/json",
+        )
+
+    if float(file_metadata.get("upload_time", 0)) + lifetime < time.time():
+        clean_files(file_token)
+        return Response(
+            json.dumps({"error": "token expired", "version": __version__}),
+            status=400,
+            mimetype="application/json",
+        )
+
+    json_file = get_json_path(file_token)
+    if json_file.is_file():
+        with json_file.open("r") as fp:
+            try:
+                json_data = json.load(fp)
+            except:
+                json_data = {}
+
+        if not json_data:
+            clean_files(file_token)
+            return Response(
+                json.dumps(
+                    {"error": "invalid model output", "version": __version__},
+                    status=400,
+                    mimetype="application/json",
+                )
+            )
+
+        json_data.update(
+            {
+                "token": file_token,
+                "status": "success",
+                "version": __version__,
+                "inference_time": float(file_metadata.get("update_time", 0))
+                - float(file_metadata.get("upload_time", 0)),
+            }
+        )
+        clean_files(file_token)
+
+        return Response(
+            json.dumps(json_data), status=200, mimetype="application/json"
+        )
+
+    prepared_files = get_prepared_paths(file_token)
+    if prepared_files:
+        output = {
+            "token": file_token,
+            "status": "success",
+            "version": __version__,
+            "inference_time": float(file_metadata.get("update_time", 0))
+            - float(file_metadata.get("upload_time", 0)),
+        }
+        if len(prepared_files) == 1:
+            output["url"] = get_url(prepared_files[0])
+        else:
+            output["urls"] = [get_url(file) for file in prepared_files]
+
+        return Response(
+            json.dumps(output), status=200, mimetype="application/json"
+        )
+
+    source_files = get_source_paths(file_token)
+    if source_files:
+        return Response(
+            json.dumps(
+                {"wait": "true", "status": "processing", "version": __version__}
+            ),
+            status=200,
+            mimetype="application/json",
+        )
+
+    staged_files = get_staged_paths(file_token)
+    if staged_files:
+        return Response(
+            json.dumps(
+                {"wait": "true", "status": "not queued", "version": __version__}
+            ),
+            status=200,
+            mimetype="application/json",
+        )
+
+    return Response(
+        json.dumps({"error": "unknown token", "version": __version__}),
+        status=400,
+        mimetype="application/json",
+    )
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", debug=True)

--- a/row_037_run.py
+++ b/row_037_run.py
@@ -1,0 +1,89 @@
+# run.py
+
+import config
+import base64, json, os
+from flask import Flask, render_template, request, make_response, send_file, Response
+from utils import get_files, get_files_json, upload_file, upload_files, delete_file, job_desc_empty
+if config.options['enable_autodesc']:
+    from flask_apscheduler import APScheduler
+
+if not os.path.exists(config.filepaths['gallery']):
+    os.mkdir(config.filepaths['gallery'])
+if not os.path.exists(config.filepaths['demo']):
+    os.mkdir(config.filepaths['demo'])
+    
+app = Flask(__name__)
+app.debug = False
+
+@app.route("/", methods = ["GET", "POST"])
+def index():
+    if request.method == "POST":
+        data = dict(request.form)
+        images = get_files(data["search"])
+    else:
+        images = get_files('')
+    return render_template(
+        "gallery.html", 
+        imgs = images
+    )
+
+@app.route("/api")
+def api():
+    results = get_files_json()
+    return Response(json.dumps(results))
+
+@app.route("/delete/<uid>", methods = ['POST'])
+def delete(uid):
+    delete_file(uid)
+    return render_template("gallery.html")
+
+@app.route('/demo', methods = ['GET', 'POST'])
+def demo():
+	files = upload_files()
+	return render_template(
+        "uploaded.html", 
+        files = files, 
+        egd = config.options['enable_autodesc']
+    )
+
+@app.route('/upload')
+def upload():
+	return render_template('upload.html')
+
+@app.route('/uploader', methods = ['GET', 'POST'])
+def uploader():
+	if request.method == 'POST':
+		file = request.files['file']
+		upload_file(file)
+		return render_template("uploaded.html", files = file, egd = config.options['enable_autodesc'])
+
+@app.route('/uploader_react', methods = ['POST'])
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+def uploader_react():
+    f = request.files['file']
+    upload_file(f)
+    # Return the original/manipulated image with more optional data as JSON
+    filepath = config.filepaths['FILE_PATH_DEMO'] + f.filename
+# defect
+    saved_img = open(filepath, 'rb').read() # Read as binary
+    saved_img_b64 = base64.b64encode(saved_img).decode('utf-8') # UTF-8 can be converted to JSON
+    response = {}
+    response['data'] = saved_img_b64
+    response['more_fields'] = 'more data' # Can return values such as Machine Learning accuracy or precision
+    # If only the image is required, you can use send_file instead
+# {/fact}
+    # return send_file('save_pic.jpg', mimetype='image/jpg') 
+    return Response(json.dumps(response))
+
+if __name__ == "__main__":
+	if config.options['enable_autodesc']:
+		scheduler = APScheduler()
+		scheduler.add_job(
+            func = job_desc_empty, 
+            args = ['Description Check'], 
+            trigger = 'interval', 
+            id = 'job',
+            seconds = config.options['job_time']
+        )
+		scheduler.start()
+	app.run(config.host_name, config.host_port)

--- a/row_061_app.py
+++ b/row_061_app.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""
+    :author: Grey Li <withlihui@gmail.com>
+    :copyright: (c) 2017 by Grey Li.
+    :license: MIT, see LICENSE for more details.
+"""
+import os
+
+from flask import Flask, render_template, request
+from flask_dropzone import Dropzone
+
+basedir = os.path.abspath(os.path.dirname(__file__))
+
+
+app = Flask(__name__)
+
+app.config.update(
+    UPLOADED_PATH=os.path.join(basedir, 'uploads'),
+    # Flask-Dropzone config:
+    DROPZONE_ALLOWED_FILE_TYPE='image',
+    DROPZONE_MAX_FILE_SIZE=3,
+    DROPZONE_MAX_FILES=30,
+    DROPZONE_REDIRECT_VIEW='completed'  # set redirect view
+)
+
+dropzone = Dropzone(app)
+
+# {fact rule=unrestricted-file-upload@v1.0 defects=0}
+
+@app.route('/', methods=['POST', 'GET'])
+def upload():
+    if request.method == 'POST':
+        f = request.files.get('file')
+# defect
+        f.save(os.path.join(app.config['UPLOADED_PATH'], f.filename))
+    return render_template('index.html')
+
+
+@app.route('/completed')
+def completed():
+# {/fact}
+    return '<h1>The Redirected Page</h1><p>Upload completed.</p>'
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
Ported from original PR: https://github.com/branedev2/oct-prs/pull/82

## 📝 Description
This PR adds a batch of Python files from the `python_unrestrictre-file-upload-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `python_unrestrictre-file-upload-annotated`
- Batch: python-unrestrictre-file-upload-annotated-python-batch-11
- Language: Python
- Contains python files collected from the source directory

## 🔍 Changes
- Added python files from `python_unrestrictre-file-upload-annotated` maintaining original directory structure
- Files organized in batch 11 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `python_unrestrictre-file-upload-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds multiple new Flask/Django services with endpoints for uploading/processing images, GIFs, text, and managing device/display actions.
> 
> - **Flask: Pixoo REST service (`row_002_app.py`)**
>   - Device control endpoints for brightness, channels, screen, text/image drawing, shapes, and pixels.
>   - Media handling: upload image/text, send GIFs, download and render image/GIF/text from URLs.
>   - Passthrough routes to device APIs and Divoom channel/device endpoints.
>   - Swagger integration and connection bootstrap to `Pixoo` device.
> - **Django: views module (`row_007_views.py`)**
>   - CRUD for students/teachers, authentication flows, sessions, PDF generation, chat, and class-based views.
>   - Email utilities (plain, with stored or uploaded attachments) and multiple/ AJAX file upload handlers.
> - **Flask: file API (`row_012_api.py`)**
>   - Upload endpoints for images (`/put/image`) and text (`/put/text`) with tokenization and metadata.
>   - Retrieval endpoints for prepared media (`/get/image/<file>`) and JSON status (`/get/json`).
>   - File lifecycle management across staged/source/prepared paths with cleanup.
> - **Flask: gallery app (`row_037_run.py`)**
>   - Gallery listing/search, delete, upload (standard and React), and demo rendering; optional APScheduler job.
> - **Flask: Dropzone upload demo (`row_061_app.py`)**
>   - Image-only uploads with Dropzone config and simple completion view.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0caa15a82290aa10a692c191c22877d0cb1e5c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->